### PR TITLE
Ensure that forward-declaration headers are included by full-declaration headers

### DIFF
--- a/inc/osvr/PluginHost/RegistrationContext.h
+++ b/inc/osvr/PluginHost/RegistrationContext.h
@@ -27,6 +27,7 @@
 #define INCLUDED_RegistrationContext_h_GUID_9FF83E64_B2E1_40B7_E072_929AC0F94A10
 
 // Internal Includes
+#include <osvr/PluginHost/RegistrationContext_fwd.h>
 #include <osvr/Util/SharedPtr.h>
 #include <osvr/Util/AnyMap.h>
 #include <osvr/PluginHost/Export.h>

--- a/inc/osvr/Util/AnyMap.h
+++ b/inc/osvr/Util/AnyMap.h
@@ -27,6 +27,7 @@
 
 // Internal Includes
 #include <osvr/Util/Export.h>
+#include <osvr/Util/AnyMap_fwd.h>
 
 // Library/third-party includes
 #include <boost/any.hpp>

--- a/inc/osvr/Util/TimeValue.h
+++ b/inc/osvr/Util/TimeValue.h
@@ -27,6 +27,7 @@
 
 // Internal Includes
 #include <osvr/Util/TimeValueC.h>
+#include <osvr/Util/TimeValue_fwd.h>
 
 // Library/third-party includes
 // - none

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -15,7 +15,6 @@ foreach(HEADER ${headers})
     if (${_index} EQUAL -1)
         string(REPLACE ".h" "" basename "${HEADER}")
         string(MAKE_C_IDENTIFIER "${basename}" basename)
-        #set(test_name "test_header_prereqs_${basename}")
         set(test_name "test_${test_index}")
 
         set(extension cpp)
@@ -51,4 +50,27 @@ foreach(HEADER ${headers})
         math(EXPR test_index "${test_index} + 1")
     endif()
 endforeach()
+
+#
+# Ensure forward-declaration headers are included in the full-declaration headers.
+# That is, ensure that Blah_fwd.h is included in Blah.h.
+#
+
+file(GLOB_RECURSE fwd_headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*_fwd.h)
+foreach(fwd_header ${fwd_headers})
+    string(REPLACE "_fwd.h" ".h" full_header "${fwd_header}")
+    file(STRINGS "${HEADER_BASE}/${full_header}" header_contents)
+    set(_found OFF)
+    foreach(line ${header_contents})
+        if ("${line}" MATCHES "#include [<\"]${fwd_header}[>\"]")
+            set(_found ON)
+            break()
+        endif()
+    endforeach()
+    if (NOT _found)
+        message(FATAL_ERROR "The header file <${full_header}> does not include <${fwd_header}>.")
+    endif()
+endforeach()
+
+
 

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -56,21 +56,11 @@ endforeach()
 # That is, ensure that Blah_fwd.h is included in Blah.h.
 #
 
-file(GLOB_RECURSE fwd_headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*_fwd.h)
-foreach(fwd_header ${fwd_headers})
-    string(REPLACE "_fwd.h" ".h" full_header "${fwd_header}")
-    file(STRINGS "${HEADER_BASE}/${full_header}" header_contents)
-    set(_found OFF)
-    foreach(line ${header_contents})
-        if ("${line}" MATCHES "#include [<\"]${fwd_header}[>\"]")
-            set(_found ON)
-            break()
-        endif()
-    endforeach()
-    if (NOT _found)
-        message(FATAL_ERROR "The header file <${full_header}> does not include <${fwd_header}>.")
-    endif()
-endforeach()
+add_test(NAME test_fwd_headers
+    COMMAND ${CMAKE_COMMAND}
+        -DHEADER_BASE=${HEADER_BASE}
+        -P "${CMAKE_CURRENT_LIST_DIR}/CheckForwardDeclarationHeaders.cmake"
+)
 
 
 

--- a/tests/header_dependencies/CheckForwardDeclarationHeaders.cmake
+++ b/tests/header_dependencies/CheckForwardDeclarationHeaders.cmake
@@ -11,9 +11,32 @@ file(TO_CMAKE_PATH "${HEADER_BASE}" HEADER_BASE)
 file(GLOB_RECURSE fwd_headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*_fwd.h)
 foreach(fwd_header ${fwd_headers})
     string(REPLACE "_fwd.h" ".h" full_header "${fwd_header}")
-    file(STRINGS "${HEADER_BASE}/${full_header}" _found REGEX "#include [<\"]${fwd_header}[>\"]")
-    if (NOT _found)
-        message(FATAL_ERROR "The header file <${full_header}> does not include <${fwd_header}>.")
+    if (EXISTS "${HEADER_BASE}/${full_header}")
+        file(STRINGS "${HEADER_BASE}/${full_header}" _found REGEX "#include [<\"]${fwd_header}[>\"]")
+        if (NOT _found)
+            message(FATAL_ERROR "The header file ${HEADER_BASE}/${full_header} does not include <${fwd_header}>.")
+        endif()
     endif()
 endforeach()
+
+#
+# Ensure that smart pointer typedef headers are inclucded in the full-declaration headers.
+# That is, ensure that BlahPtr.h is included in Blah.h
+#
+# Variables:
+#
+#   HEADER_BASE  Set this to the root directory containing the header files to be checked.
+#
+
+file(GLOB_RECURSE ptr_headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*Ptr.h)
+foreach(ptr_header ${ptr_headers})
+    string(REPLACE "Ptr.h" ".h" full_header "${ptr_header}")
+    if (EXISTS "${HEADER_BASE}/${full_header}")
+        file(STRINGS "${HEADER_BASE}/${full_header}" _found REGEX "#include [<\"]${ptr_header}[>\"]")
+        if (NOT _found)
+            message(FATAL_ERROR "The header file ${HEADER_BASE}/${full_header} does not include <${ptr_header}>.")
+        endif()
+    endif()
+endforeach()
+
 

--- a/tests/header_dependencies/CheckForwardDeclarationHeaders.cmake
+++ b/tests/header_dependencies/CheckForwardDeclarationHeaders.cmake
@@ -1,0 +1,19 @@
+#
+# Ensure forward-declaration headers are included in the full-declaration headers.
+# That is, ensure that Blah_fwd.h is included in Blah.h.
+#
+# Variables:
+#
+#   HEADER_BASE  Set this to the root directory containing the header files to be checked.
+#
+
+file(TO_CMAKE_PATH "${HEADER_BASE}" HEADER_BASE)
+file(GLOB_RECURSE fwd_headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*_fwd.h)
+foreach(fwd_header ${fwd_headers})
+    string(REPLACE "_fwd.h" ".h" full_header "${fwd_header}")
+    file(STRINGS "${HEADER_BASE}/${full_header}" _found REGEX "#include [<\"]${fwd_header}[>\"]")
+    if (NOT _found)
+        message(FATAL_ERROR "The header file <${full_header}> does not include <${fwd_header}>.")
+    endif()
+endforeach()
+


### PR DESCRIPTION
Added tests to sure that `_fwd.h` and `Ptr.h` headers are included in their primary header files.

Running `ctest -R test_fwd_headers` will execute this test.

Fixed headers that failed this test.