### PR TITLE
Android binary location

### DIFF
--- a/cmake/PlatformDefinitions.cmake
+++ b/cmake/PlatformDefinitions.cmake
@@ -22,6 +22,7 @@ endfunction()
 
 macro(define_platform_macros _prefix)
 	_define_platform_macros_impl(${_prefix} "AIX" AIX)
+	_define_platform_macros_impl(${_prefix} "Android" ANDROID)
 	_define_platform_macros_impl(${_prefix} "BS/DOS" BSDOS)
 	_define_platform_macros_impl(${_prefix} "FreeBSD" FREEBSD)
 	_define_platform_macros_impl(${_prefix} "HP-UX" HPUX)

--- a/src/osvr/PluginHost/BinaryLocation.cpp
+++ b/src/osvr/PluginHost/BinaryLocation.cpp
@@ -33,6 +33,7 @@
 #endif // OSVR_WINDOWS
 
 #include <boost/filesystem.hpp>
+#include <cstring>
 
 // Standard includes
 // - none
@@ -67,6 +68,10 @@ namespace pluginhost {
         } else {
             // sysctl CTL_KERN KERN_PROC KERN_PROC_PATHNAME -1
         }
+    }
+#elif defined(OSVR_ANDROID)
+    std::string getBinaryLocation() {
+        return boost::filesystem::canonical("/proc/self/exe").generic_string();
     }
 #else
 #error "getBinaryLocation() not yet implemented for this platform!"

--- a/src/osvr/PluginHost/BinaryLocation.cpp
+++ b/src/osvr/PluginHost/BinaryLocation.cpp
@@ -33,7 +33,6 @@
 #endif // OSVR_WINDOWS
 
 #include <boost/filesystem.hpp>
-#include <cstring>
 
 // Standard includes
 // - none

--- a/src/osvr/Util/PlatformConfig.h.in
+++ b/src/osvr/Util/PlatformConfig.h.in
@@ -63,6 +63,7 @@
  */
 //@{
 #cmakedefine OSVR_AIX
+#cmakedefine OSVR_ANDROID
 #cmakedefine OSVR_BSDOS
 #cmakedefine OSVR_FREEBSD
 #cmakedefine OSVR_HPUX


### PR DESCRIPTION
Added OSVR_ANDROID platform definition. Handled OSVR_ANDROID case identically to OSVR_LINUX. It gets past the getBinaryLocation() not implemented error.