### PR TITLE
Test multiple contexts

### DIFF
--- a/tests/cplusplus/CMakeLists.txt
+++ b/tests/cplusplus/CMakeLists.txt
@@ -13,3 +13,7 @@ add_subdirectory(Common)
 if(BUILD_SERVER)
     add_subdirectory(Connection)
 endif()
+
+if(BUILD_CLIENT)
+    add_subdirectory(ClientKit)
+endif()

--- a/tests/cplusplus/ClientKit/CMakeLists.txt
+++ b/tests/cplusplus/ClientKit/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(TestSimultaneousContexts
+    SimultaneousContexts.cpp)
+target_link_libraries(TestSimultaneousContexts osvrClientKitCpp)
+setup_gtest(TestSimultaneousContexts)
+
+add_executable(TestSequentialContexts
+    SequentialContexts.cpp)
+target_link_libraries(TestSequentialContexts osvrClientKitCpp)
+setup_gtest(TestSequentialContexts)

--- a/tests/cplusplus/ClientKit/CMakeLists.txt
+++ b/tests/cplusplus/ClientKit/CMakeLists.txt
@@ -1,9 +1,7 @@
-add_executable(TestSimultaneousContexts
-    SimultaneousContexts.cpp)
-target_link_libraries(TestSimultaneousContexts osvrClientKitCpp)
-setup_gtest(TestSimultaneousContexts)
 
-add_executable(TestSequentialContexts
-    SequentialContexts.cpp)
-target_link_libraries(TestSequentialContexts osvrClientKitCpp)
-setup_gtest(TestSequentialContexts)
+foreach(test SimultaneousContexts SequentialContexts OverlappedContexts)
+    add_executable(Test${test}
+        ${test}.cpp)
+    target_link_libraries(Test${test} osvrClientKitCpp)
+    setup_gtest(Test${test})
+endforeach()

--- a/tests/cplusplus/ClientKit/OverlappedContexts.cpp
+++ b/tests/cplusplus/ClientKit/OverlappedContexts.cpp
@@ -1,0 +1,43 @@
+/** @file
+    @brief Test Implementation
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/ClientKit/Context.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include "gtest/gtest.h"
+
+TEST(OverlappedContexts, TwoContexts) {
+    OSVR_ClientContext firstContext =
+        osvrClientInit("com.osvr.test.firstContext");
+    OSVR_ClientContext secondContext =
+        osvrClientInit("com.osvr.test.secondContext");
+    ASSERT_EQ(OSVR_RETURN_SUCCESS, osvrClientShutdown(firstContext));
+    osvrClientUpdate(secondContext);
+    ASSERT_EQ(OSVR_RETURN_SUCCESS, osvrClientShutdown(secondContext));
+}

--- a/tests/cplusplus/ClientKit/SequentialContexts.cpp
+++ b/tests/cplusplus/ClientKit/SequentialContexts.cpp
@@ -1,0 +1,44 @@
+/** @file
+    @brief Test Implementation
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/ClientKit/Context.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include "gtest/gtest.h"
+
+TEST(SequentialClient, TwoContexts) {
+    {
+        osvr::clientkit::ClientContext firstContext(
+            "com.osvr.test.firstContext");
+    }
+    {
+        osvr::clientkit::ClientContext secondContext(
+            "com.osvr.test.secondContext");
+    }
+}

--- a/tests/cplusplus/ClientKit/SimultaneousContexts.cpp
+++ b/tests/cplusplus/ClientKit/SimultaneousContexts.cpp
@@ -1,0 +1,40 @@
+/** @file
+    @brief Test Implementation
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/ClientKit/Context.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include "gtest/gtest.h"
+
+TEST(SimultaneousClient, TwoContexts) {
+    osvr::clientkit::ClientContext outerContext("com.osvr.test.outerContext");
+    {
+        osvr::clientkit::ClientContext innerContext("com.osvr.test.innerContext");
+    }
+}

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -42,7 +42,8 @@ foreach(HEADER ${headers})
         #message(STATUS "${HEADER}: '${symbolname}' - '${libname}'")
 
         # Name the test and output file with a number, to dodge Windows path length limits.
-        set(test_name "test_${test_index}")
+        # Call it header, instead of test, to avoid polluting the 'executable'
+        set(test_name "header_${test_index}")
 
         set(extension cpp)
         if (${HEADER} MATCHES "C.h$")


### PR DESCRIPTION
Sequential and simultaneous are in separate executables, to ensure
no (presumably external, VRPN) global state pollutes the test.

All tests pass.