### PR TITLE
Build config improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ if(CMAKE_VERSION VERSION_LESS 3.0.0)
     message(FATAL_ERROR "You must use CMake 3.0.0 or greater.")
 endif()
 
+if(ANDROID AND CMAKE_VERSION VERSION_LESS 3.1.0)
+    message(FATAL_ERROR "You must use CMake 3.1.0 or greater to build for Android.")
+endif()
+
 set(LOCAL_CMAKE_MODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake-local")
 # Custom CMake modules from https://github.com/rpavlik/cmake-modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${LOCAL_CMAKE_MODULE_DIR}")

--- a/cmake-local/osvrConfig.cmake
+++ b/cmake-local/osvrConfig.cmake
@@ -2,6 +2,9 @@
 # File will only exist in build trees - provides hints to dependencies
 include("${CMAKE_CURRENT_LIST_DIR}/osvrConfigBuildTreePaths.cmake" OPTIONAL)
 
+# Hook for a super-build to optionally inject hints before target import.
+include("${CMAKE_CURRENT_LIST_DIR}/osvrConfigSuperBuildPrefix.cmake" OPTIONAL)
+
 # Dependency of PluginKit
 find_package(libfunctionality QUIET)
 
@@ -19,6 +22,9 @@ set(OSVR_CACHED_PLUGIN_DIR "@OSVR_PLUGIN_DIR@" CACHE INTERNAL
 
 set(OSVR_PLUGIN_IGNORE_SUFFIX "@OSVR_PLUGIN_IGNORE_SUFFIX@" CACHE INTERNAL
     "The additional suffix for OSVR plugins that are not to be auto-loaded" FORCE)
+
+# Hook for a super-build to optionally inject configuration after target import.
+include("${CMAKE_CURRENT_LIST_DIR}/osvrConfigSuperBuildSuffix.cmake" OPTIONAL)
 
 # Since alias targets only work for libraries, we use this method instead to
 # share the osvr_convert_json script between the main tree and external config users.


### PR DESCRIPTION
Improve CMake config files to make cross-building plugins easier.

More improvements related to building are likely, so not ready to merge this one yet - no need to trigger build+deploy across the board quite yet.