### PR TITLE
Check display startup

### DIFF
--- a/inc/osvr/Client/DisplayConfig.h
+++ b/inc/osvr/Client/DisplayConfig.h
@@ -79,6 +79,8 @@ namespace client {
                                              OSVR_EyeCount eye,
                                              OSVR_SurfaceCount surface) const;
 
+        OSVR_CLIENT_EXPORT bool isStartupComplete() const;
+
       private:
         friend class DisplayConfigFactory;
         DisplayConfig();

--- a/inc/osvr/ClientKit/DisplayC.h
+++ b/inc/osvr/ClientKit/DisplayC.h
@@ -70,6 +70,16 @@ osvrClientGetDisplay(OSVR_ClientContext ctx, OSVR_DisplayConfig *disp);
 OSVR_CLIENTKIT_EXPORT OSVR_ReturnCode
 osvrClientFreeDisplay(OSVR_DisplayConfig disp);
 
+/** @brief Checks to see if a display is fully configured and ready, including
+   having received its first pose update.
+
+
+    @return OSVR_RETURN_FAILURE if a null config was passed, or if the given
+    display config object was otherwise not ready for full use.
+*/
+OSVR_CLIENTKIT_EXPORT OSVR_ReturnCode
+osvrClientCheckDisplayStartup(OSVR_DisplayConfig disp);
+
 /** @brief A display config can have one (or theoretically more) viewers */
 OSVR_CLIENTKIT_EXPORT OSVR_ReturnCode
 osvrClientGetNumViewers(OSVR_DisplayConfig disp, OSVR_ViewerCount *viewers);

--- a/src/osvr/Client/DisplayConfig.cpp
+++ b/src/osvr/Client/DisplayConfig.cpp
@@ -146,5 +146,19 @@ namespace client {
         }
     }
     DisplayConfig::DisplayConfig() {}
+
+    bool DisplayConfig::isStartupComplete() const {
+        for (auto const &viewer : *this) {
+            if (!viewer.hasPose()) {
+                return false;
+            }
+            for (auto const& eye : viewer) {
+                if (!eye.hasPose()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 } // namespace client
 } // namespace osvr

--- a/src/osvr/ClientKit/DisplayC.cpp
+++ b/src/osvr/ClientKit/DisplayC.cpp
@@ -130,6 +130,12 @@ OSVR_ReturnCode osvrClientFreeDisplay(OSVR_DisplayConfig disp) {
     return freed ? OSVR_RETURN_SUCCESS : OSVR_RETURN_FAILURE;
 }
 
+OSVR_ReturnCode
+osvrClientCheckDisplayStartup(OSVR_DisplayConfig disp) {
+    OSVR_VALIDATE_DISPLAY_CONFIG;
+    return disp->cfg->isStartupComplete() ? OSVR_RETURN_SUCCESS : OSVR_RETURN_FAILURE;
+}
+
 OSVR_ReturnCode osvrClientGetNumViewers(OSVR_DisplayConfig disp,
                                         OSVR_ViewerCount *viewers) {
     OSVR_VALIDATE_DISPLAY_CONFIG;


### PR DESCRIPTION
Adds an API method to find out if the display is fully ready to go. Not sure if this should be merged or not, but figured it's worth bringing up for conversation.