### PR TITLE
Fix building for Linux using Boost 1.58.0

### DIFF
--- a/src/osvr/Common/NormalizeDeviceDescriptor.cpp
+++ b/src/osvr/Common/NormalizeDeviceDescriptor.cpp
@@ -24,6 +24,7 @@
 // limitations under the License.
 
 // Internal Includes
+#include <boost/type_traits/remove_cv.hpp>
 #include <osvr/Common/NormalizeDeviceDescriptor.h>
 
 // Library/third-party includes


### PR DESCRIPTION
There's an upstream bug in Boost that forgets to include this header and results in a compilation error. I believe this has been fixed for Boost 1.59.x, but in the mean time this will allow compilation without issues.