### PR TITLE
Added the current working directory to the plugin search path.

### DIFF
--- a/src/osvr/PluginHost/SearchPath.cpp
+++ b/src/osvr/PluginHost/SearchPath.cpp
@@ -54,15 +54,15 @@ namespace pluginhost {
         // binDir now normalized to PREFIX/bin
         auto root = binDir.parent_path();
 
-        // current working directory
-        auto currentWorkingDirectory = boost::filesystem::current_path();
-
         SearchPath paths;
 
+#ifdef __ANDROID__
         // current working directory, if different from root
+        auto currentWorkingDirectory = boost::filesystem::current_path();
         if (currentWorkingDirectory != root) {
             paths.push_back((currentWorkingDirectory / OSVR_PLUGIN_DIR).string());
         }
+#endif
 
 #ifdef _MSC_VER
         paths.push_back((root / OSVR_PLUGIN_DIR / CMAKE_INTDIR).string());

--- a/src/osvr/PluginHost/SearchPath.cpp
+++ b/src/osvr/PluginHost/SearchPath.cpp
@@ -54,7 +54,16 @@ namespace pluginhost {
         // binDir now normalized to PREFIX/bin
         auto root = binDir.parent_path();
 
+        // current working directory
+        auto currentWorkingDirectory = boost::filesystem::current_path();
+
         SearchPath paths;
+
+        // current working directory, if different from root
+        if (currentWorkingDirectory != root) {
+            paths.push_back((currentWorkingDirectory / OSVR_PLUGIN_DIR).string());
+        }
+
 #ifdef _MSC_VER
         paths.push_back((root / OSVR_PLUGIN_DIR / CMAKE_INTDIR).string());
 #endif


### PR DESCRIPTION
Specifically, the current working directory plus the OSVR_PLUGIN_DIR predefine subpath, and only if the CWD is not the same as the root (to avoid duplicate paths).

cc: https://github.com/OSVR/OSVR-Core/issues/208