### PR TITLE
Don't always hardware detect

### DIFF
--- a/inc/osvr/Server/Server.h
+++ b/inc/osvr/Server/Server.h
@@ -137,6 +137,13 @@ namespace server {
         /// @brief Load all auto-loadable plugins.
         OSVR_SERVER_EXPORT void loadAutoPlugins();
 
+        /// @brief Adds the behavior that hardware detection should take place
+        /// on client connection.
+        ///
+        /// Safe to call from any thread, even when server is running, though it
+        /// makes the most sense as a startup option.
+        OSVR_SERVER_EXPORT void setHardwareDetectOnConnection();
+
         /// @brief Instantiate the named driver with parameters.
         /// @param plugin The name of a plugin.
         /// @param driver The name of a driver registered by the plugin for

--- a/src/osvr/Server/ConfigureServer.cpp
+++ b/src/osvr/Server/ConfigureServer.cpp
@@ -149,8 +149,9 @@ namespace server {
             m_server = Server::create(connPtr);
         }
 
-        if (sleepTime > 0.0)
+        if (sleepTime > 0.0) {
             m_server->setSleepTime(sleepTime);
+        }
 
         m_server->setHardwareDetectOnConnection();
 

--- a/src/osvr/Server/ConfigureServer.cpp
+++ b/src/osvr/Server/ConfigureServer.cpp
@@ -152,6 +152,8 @@ namespace server {
         if (sleepTime > 0.0)
             m_server->setSleepTime(sleepTime);
 
+        m_server->setHardwareDetectOnConnection();
+
         return m_server;
     }
 

--- a/src/osvr/Server/Server.cpp
+++ b/src/osvr/Server/Server.cpp
@@ -66,6 +66,10 @@ namespace server {
 
     void Server::loadAutoPlugins() { m_impl->loadAutoPlugins(); }
 
+    void Server::setHardwareDetectOnConnection() {
+        m_impl->setHardwareDetectOnConnection();
+    }
+
     void Server::instantiateDriver(std::string const &plugin,
                                    std::string const &driver,
                                    std::string const &params) {

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -90,10 +90,9 @@ namespace server {
             &ServerImpl::m_handleUpdatedRoute, this);
 
         // Things to do when we get a new incoming connection
+        // No longer doing hardware detect unconditionally here - see triggerHardwareDetect()
         m_commonComponent =
             m_systemDevice->addComponent(common::CommonComponent::create());
-        m_commonComponent->registerPingHandler(
-            [&] { triggerHardwareDetect(); });
         m_commonComponent->registerPingHandler([&] { m_sendTree(); });
 
         // Set up the default display descriptor.
@@ -156,6 +155,11 @@ namespace server {
     }
 
     void ServerImpl::loadAutoPlugins() { m_ctx->loadPlugins(); }
+
+    void ServerImpl::setHardwareDetectOnConnection() {
+        m_commonComponent->registerPingHandler(
+            [&] { triggerHardwareDetect(); });
+    }
 
     void ServerImpl::instantiateDriver(std::string const &plugin,
                                        std::string const &driver,

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -84,6 +84,9 @@ namespace server {
         /// @brief Load all auto-loadable plugins.
         void loadAutoPlugins();
 
+        /// @copydoc Server::setHardwareDetectOnConnection()
+        void setHardwareDetectOnConnection();
+
         /// @copydoc Server::triggerHardwareDetect()
         void triggerHardwareDetect();
 


### PR DESCRIPTION
Leaves the "hardware detect on client connect" behavior in place for a standalone OSVR server, but makes it optional in the library so that JointClientKit doesn't get automatically, since it doesn't make sense there.

@JeroMiya - should be helpful to you?