### PR TITLE
Add default constructor to DisplayInput to fix compile with Clang and libc++

### DIFF
--- a/inc/osvr/Client/DisplayInput.h
+++ b/inc/osvr/Client/DisplayInput.h
@@ -40,6 +40,7 @@ namespace client {
     class DisplayConfigFactory;
     class DisplayInput {
       public:
+        DisplayInput();
         DisplayInput(OSVR_DisplayDimension width, OSVR_DisplayDimension height);
 
         OSVR_CLIENT_EXPORT OSVR_DisplayDimension getDisplayWidth() const;

--- a/src/osvr/Client/DisplayInput.cpp
+++ b/src/osvr/Client/DisplayInput.cpp
@@ -33,6 +33,9 @@
 
 namespace osvr {
 namespace client {
+    DisplayInput::DisplayInput() {
+        // do nothing
+    }
     DisplayInput::DisplayInput(OSVR_DisplayDimension width,
                                OSVR_DisplayDimension height)
         : m_width(width), m_height(height) {}


### PR DESCRIPTION
The lack of a default constructor for the DisplayInput class causes a compile error at https://github.com/OSVR/OSVR-Core/blob/master/src/osvr/Client/DisplayConfig.cpp#L150 . This is because resize( size_type count ) requires a default constructor, in case the vector is being enlarged. Obviously the vector is not being enlarged in this instance, but this does trip up Clang when using libc++.