### PR TITLE
Support build with Boost 1.59.0

### DIFF
--- a/src/osvr/Common/IPCRingBuffer.cpp
+++ b/src/osvr/Common/IPCRingBuffer.cpp
@@ -51,7 +51,7 @@ namespace common {
 
 /// Some tests that can be automated for ensuring validity of the ABI level
 /// number.
-#if (BOOST_VERSION > 105800)
+#if (BOOST_VERSION > 105900)
 #error                                                                         \
     "Using an untested Boost version - inspect the Boost Interprocess release notes/changelog to see if any ABI breaks affect us."
 #endif


### PR DESCRIPTION
I reviewed the changelog at http://www.boost.org/users/history/version_1_59_0.html and I see no changes in Interprocess that should affect us. There are changes to Fusion which appear to cause issues on Windows though, as we can see in https://github.com/OSVR/OSVR-Core/issues/193 — I haven't looked at these yet.