### PR TITLE
Fix fusion vector size

### DIFF
--- a/inc/osvr/Common/ReportTypes.h
+++ b/inc/osvr/Common/ReportTypes.h
@@ -26,6 +26,7 @@
 #define INCLUDED_ReportTypes_h_GUID_BB8F47AD_5F82_439E_C3F9_7C57D016D3C9
 
 // Internal Includes
+#define FUSION_MAX_VECTOR_SIZE 20 //Default is 10, too small for typelist
 #include <osvr/Util/ClientCallbackTypesC.h>
 
 // Library/third-party includes


### PR DESCRIPTION
This fixes https://github.com/OSVR/OSVR-Core/issues/193 (and probably https://github.com/OSVR/OSVR-Core/issues/177 too as the error output looks very similar, but I haven't tested). I realized that this was going on by looking carefully at the "notes" that MSVC produced and noticing that the pairs at the beginning of the generated list were getting trashed. This probably affects other platforms too, but is just not caught...

(This is partially documented here: http://www.boost.org/doc/libs/1_59_0/libs/fusion/doc/html/fusion/container/vector.html — what is not documented is that mpl vector to fusion vector conversions are affected.)