### PR TITLE
Remove unnecessary SourceAnnotations.h include

### DIFF
--- a/inc/osvr/Util/AnnotationMacrosC.h
+++ b/inc/osvr/Util/AnnotationMacrosC.h
@@ -39,7 +39,6 @@
 /* Using SAL attribute format:
  * http://msdn.microsoft.com/en-us/library/ms182032(v=vs.120).aspx */
 
-#include <CodeAnalysis/SourceAnnotations.h>
 #include <sal.h>
 
 #define OSVR_IN _In_


### PR DESCRIPTION
&lt;CodeAnalysis/SourceAnnotations.h&gt; is automatically included from &lt;sal.h&gt; when necessary, and including it here separately breaks build for the C-only components. This is necessary for clean building with VS2015.