### PR TITLE
Implement getSerialDeviceList for Mac OS X

### DIFF
--- a/src/osvr/USBSerial/CMakeLists.txt
+++ b/src/osvr/USBSerial/CMakeLists.txt
@@ -42,3 +42,12 @@ if(WIN32)
         wbemuuid
         com_smart_pointer)
 endif()
+if(APPLE)
+    # find_library must be used for OS X frameworks
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    find_library(IOKIT_LIBRARY IOKit)
+    target_link_libraries(${LIBNAME_FULL}
+        PRIVATE
+        ${COREFOUNDATION_LIBRARY}
+        ${IOKIT_LIBRARY})
+endif()

--- a/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
+++ b/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
@@ -61,24 +61,22 @@ namespace usbserial {
          * @return 0 on success, -1 on failure
          */
         int findSerialPorts(io_iterator_t *matchingServices) {
-
-            kern_return_t kernResult;
             // Query IOKit for services matching kIOSerialBSDServiceValue
             CFMutableDictionaryRef classesToMatch =
                 IOServiceMatching(kIOSerialBSDServiceValue);
             if (classesToMatch == NULL) {
-                return -1;
+                return false;
             }
             // Query only for serial ports
             CFDictionarySetValue(classesToMatch, CFSTR(kIOSerialBSDTypeKey),
                                  CFSTR(kIOSerialBSDAllTypes));
             // Run the query
-            kernResult = IOServiceGetMatchingServices(
+            kern_return_t kernResult = IOServiceGetMatchingServices(
                 kIOMasterPortDefault, classesToMatch, matchingServices);
             if (KERN_SUCCESS != kernResult) {
-                return -1;
+                return false;
             }
-            return 0;
+            return true;
         }
 
         /**
@@ -113,7 +111,7 @@ namespace usbserial {
         io_iterator_t serialPortIterator;
         io_object_t serialPortService;
         // find all serial ports
-        if (findSerialPorts(&serialPortIterator) == 0) {
+        if (findSerialPorts(&serialPortIterator) == true) {
             // iterate over serial ports, getting vid and pid
             while ((serialPortService = IOIteratorNext(serialPortIterator)) !=
                    0) {

--- a/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
+++ b/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
@@ -37,9 +37,9 @@
 #include <string>
 #include <fstream>
 
-#include <fcntl.h>        // for O_NONBLOCK
-#include <sys/ioctl.h>    // for ioctl
-#include <unistd.h>       // for open, close
+#include <fcntl.h>     // for O_NONBLOCK
+#include <sys/ioctl.h> // for ioctl
+#include <unistd.h>    // for open, close
 
 // System includes
 #include <CoreFoundation/CoreFoundation.h>
@@ -54,31 +54,53 @@ namespace usbserial {
     namespace {
 
         /**
-         * Helper function that returns an IOKit iterator for all serial ports on the system.
-         * @param matchingServices pointer which will be set to the value of the iterator
+         * Helper function that returns an IOKit iterator for all serial ports
+         * on the system.
+         * @param matchingServices pointer which will be set to the value of the
+         * iterator
          * @return 0 on success, -1 on failure
          */
         int findSerialPorts(io_iterator_t *matchingServices) {
 
             kern_return_t kernResult;
-            CFMutableDictionaryRef classesToMatch;
             // Query IOKit for services matching kIOSerialBSDServiceValue
-            classesToMatch = IOServiceMatching(kIOSerialBSDServiceValue);
+            CFMutableDictionaryRef classesToMatch =
+                IOServiceMatching(kIOSerialBSDServiceValue);
             if (classesToMatch == NULL) {
                 return -1;
             }
-            else {
-                // Query only for serial ports
-                CFDictionarySetValue(classesToMatch,
-                                     CFSTR(kIOSerialBSDTypeKey),
-                                     CFSTR(kIOSerialBSDAllTypes));
-            }
+            // Query only for serial ports
+            CFDictionarySetValue(classesToMatch, CFSTR(kIOSerialBSDTypeKey),
+                                 CFSTR(kIOSerialBSDAllTypes));
             // Run the query
-            kernResult = IOServiceGetMatchingServices(kIOMasterPortDefault, classesToMatch, matchingServices);
-            if(KERN_SUCCESS !=kernResult) {
+            kernResult = IOServiceGetMatchingServices(
+                kIOMasterPortDefault, classesToMatch, matchingServices);
+            if (KERN_SUCCESS != kernResult) {
                 return -1;
             }
             return 0;
+        }
+
+        /**
+         * Predicate that determines if the given vendor and product IDs match
+         * that of the provided USB serial device. If the @param vendorID or
+         * @param productID is @c boost::none, that parameter will match and ID.
+         *
+         * @param device the USB serial device to compare against
+         * @param vendorID optional vendor ID
+         * @param productID optional product ID
+         *
+         * @return true if the vendor and product IDs match, false otherwise
+         */
+        bool matches_ids(const USBSerialDevice &device,
+                         const boost::optional<uint16_t> &vendorID,
+                         const boost::optional<uint16_t> &productID) {
+            const bool vendor_matches =
+                (!vendorID || *vendorID == device.getVID());
+            const bool product_matches =
+                (!productID || *productID == device.getPID());
+
+            return (vendor_matches && product_matches);
         }
     }
 
@@ -91,50 +113,51 @@ namespace usbserial {
         io_iterator_t serialPortIterator;
         io_object_t serialPortService;
         // find all serial ports
-        if(findSerialPorts(&serialPortIterator) != 0) {
-            goto bailout;
-        }
+        if (findSerialPorts(&serialPortIterator) == 0) {
+            // iterate over serial ports, getting vid and pid
+            while ((serialPortService = IOIteratorNext(serialPortIterator)) !=
+                   0) {
+                const CFNumberRef vidObj =
+                    static_cast<CFNumberRef>(IORegistryEntrySearchCFProperty(
+                        serialPortService, kIOServicePlane, CFSTR("idVendor"),
+                        NULL, kIORegistryIterateRecursively |
+                                  kIORegistryIterateParents));
+                const CFNumberRef pidObj =
+                    static_cast<CFNumberRef>(IORegistryEntrySearchCFProperty(
+                        serialPortService, kIOServicePlane, CFSTR("idProduct"),
+                        NULL, kIORegistryIterateRecursively |
+                                  kIORegistryIterateParents));
+                const CFStringRef bsdPathObj =
+                    static_cast<CFStringRef>(IORegistryEntryCreateCFProperty(
+                        serialPortService, CFSTR(kIOCalloutDeviceKey),
+                        kCFAllocatorDefault, 0));
 
-        // iterate over serial ports, getting vid and pid
-        while((serialPortService = IOIteratorNext(serialPortIterator)) != 0) {
-            const CFNumberRef vidObj = static_cast<CFNumberRef> (IORegistryEntrySearchCFProperty(serialPortService
-                                                                                 , kIOServicePlane
-                                                                                 , CFSTR("idVendor")
-                                                                                 , NULL
-                                                                                 , kIORegistryIterateRecursively | kIORegistryIterateParents));
-            const CFNumberRef pidObj = static_cast<CFNumberRef> (IORegistryEntrySearchCFProperty(serialPortService
-                                                                                 , kIOServicePlane
-                                                                                 , CFSTR("idProduct")
-                                                                                 , NULL
-                                                                                 , kIORegistryIterateRecursively | kIORegistryIterateParents));
-            const CFStringRef bsdPathObj = static_cast<CFStringRef> (IORegistryEntryCreateCFProperty(serialPortService,
-                                                                          CFSTR(kIOCalloutDeviceKey),
-                                                                          kCFAllocatorDefault,
-                                                                          0));
-
-            if(vidObj != NULL && pidObj != NULL && bsdPathObj != NULL) {
+                if (!vidObj || !pidObj || !bsdPathObj) {
+                    continue;
+                }
                 // handle device
                 uint16_t vid, pid;
                 CFNumberGetValue(vidObj, kCFNumberSInt16Type, &vid);
                 CFNumberGetValue(pidObj, kCFNumberSInt16Type, &pid);
 
-                // printf("ALL DATA: VID: %d, PID: %d, PATH: %s\n", vid, pid, bsdPathBuf);
-                if(vid == vendorID && pid == productID) {
-                    // convert the string object into a C-string
-                    CFIndex bufferSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(bsdPathObj), kCFStringEncodingMacRoman) + sizeof('\0');
-                    std::vector<char> bsdPathBuf(bufferSize);
-                    CFStringGetCString(bsdPathObj, &bsdPathBuf[0]
-                        , bufferSize, kCFStringEncodingMacRoman);
-                    // create the device
-                    USBSerialDevice usb_serial_device(vid,
-                                                      pid,
-                                                      &bsdPathBuf[0], &bsdPathBuf[0]);
+                // convert the string object into a C-string
+                CFIndex bufferSize = CFStringGetMaximumSizeForEncoding(
+                                         CFStringGetLength(bsdPathObj),
+                                         kCFStringEncodingMacRoman) +
+                                     sizeof('\0');
+                std::vector<char> bsdPathBuf(bufferSize);
+                CFStringGetCString(bsdPathObj, &bsdPathBuf[0], bufferSize,
+                                   kCFStringEncodingMacRoman);
+                // create the device
+                USBSerialDevice usb_serial_device(vid, pid, &bsdPathBuf[0],
+                                                  &bsdPathBuf[0]);
+                // check if IDs match and add
+                if (matches_ids(usb_serial_device, vendorID, productID)) {
                     devices.push_back(usb_serial_device);
                 }
             }
         }
 
-    bailout:
         return devices;
     }
 

--- a/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
+++ b/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
@@ -97,20 +97,20 @@ namespace usbserial {
 
         // iterate over serial ports, getting vid and pid
         while((serialPortService = IOIteratorNext(serialPortIterator)) != 0) {
-            CFNumberRef vidObj = (CFNumberRef) IORegistryEntrySearchCFProperty(serialPortService
+            const CFNumberRef vidObj = static_cast<CFNumberRef> (IORegistryEntrySearchCFProperty(serialPortService
                                                                                  , kIOServicePlane
                                                                                  , CFSTR("idVendor")
                                                                                  , NULL
-                                                                                 , kIORegistryIterateRecursively | kIORegistryIterateParents);
-            CFNumberRef pidObj = (CFNumberRef) IORegistryEntrySearchCFProperty(serialPortService
+                                                                                 , kIORegistryIterateRecursively | kIORegistryIterateParents));
+            const CFNumberRef pidObj = static_cast<CFNumberRef> (IORegistryEntrySearchCFProperty(serialPortService
                                                                                  , kIOServicePlane
                                                                                  , CFSTR("idProduct")
                                                                                  , NULL
-                                                                                 , kIORegistryIterateRecursively | kIORegistryIterateParents);
-            CFStringRef bsdPathObj = (CFStringRef) IORegistryEntryCreateCFProperty(serialPortService,
+                                                                                 , kIORegistryIterateRecursively | kIORegistryIterateParents));
+            const CFStringRef bsdPathObj = static_cast<CFStringRef> (IORegistryEntryCreateCFProperty(serialPortService,
                                                                           CFSTR(kIOCalloutDeviceKey),
                                                                           kCFAllocatorDefault,
-                                                                          0);
+                                                                          0));
 
             if(vidObj != NULL && pidObj != NULL && bsdPathObj != NULL) {
                 // handle device
@@ -122,14 +122,14 @@ namespace usbserial {
                 if(vid == vendorID && pid == productID) {
                     // convert the string object into a C-string
                     CFIndex bufferSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(bsdPathObj), kCFStringEncodingMacRoman) + sizeof('\0');
-                    char *  bsdPathBuf     = (char *) malloc(bufferSize);
-                    CFStringGetCString(bsdPathObj, bsdPathBuf, bufferSize, kCFStringEncodingMacRoman);
+                    std::vector<char> bsdPathBuf(bufferSize);
+                    CFStringGetCString(bsdPathObj, &bsdPathBuf[0]
+                        , bufferSize, kCFStringEncodingMacRoman);
                     // create the device
                     USBSerialDevice usb_serial_device(vid,
                                                       pid,
-                                                      bsdPathBuf, bsdPathBuf);
+                                                      &bsdPathBuf[0], &bsdPathBuf[0]);
                     devices.push_back(usb_serial_device);
-                    free(bsdPathBuf);
                 }
             }
         }

--- a/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
+++ b/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
@@ -26,27 +26,12 @@
 // Internal Includes
 #include "USBSerialDevInfo.h"
 
-// Library/third-party includes
-#include <boost/filesystem.hpp>
-#include <boost/range/iterator_range.hpp>
-#include <boost/algorithm/string.hpp>
-
-// Standard includes
-#include <iostream>
-#include <vector>
-#include <string>
-#include <fstream>
-
-#include <fcntl.h>     // for O_NONBLOCK
-#include <sys/ioctl.h> // for ioctl
-#include <unistd.h>    // for open, close
 
 // System includes
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/serial/IOSerialKeys.h>
-#include <IOKit/usb/IOUSBLib.h>
 
 namespace osvr {
 namespace usbserial {

--- a/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
+++ b/src/osvr/USBSerial/USBSerialDevInfo_MacOSX.h
@@ -129,11 +129,11 @@ namespace usbserial {
                                          kCFStringEncodingMacRoman) +
                                      sizeof('\0');
                 std::vector<char> bsdPathBuf(bufferSize);
-                CFStringGetCString(bsdPathObj, &bsdPathBuf[0], bufferSize,
+                CFStringGetCString(bsdPathObj, bsdPathBuf.data(), bufferSize,
                                    kCFStringEncodingMacRoman);
                 // create the device
-                USBSerialDevice usb_serial_device(vid, pid, &bsdPathBuf[0],
-                                                  &bsdPathBuf[0]);
+                USBSerialDevice usb_serial_device(vid, pid, bsdPathBuf.data(),
+                                                  bsdPathBuf.data());
                 // check if IDs match and add
                 if (matches_ids(usb_serial_device, vendorID, productID)) {
                     devices.push_back(usb_serial_device);


### PR DESCRIPTION
Here is an implementation of getSerialDeviceList for Mac OS X. I have tested this outside of OSVR with a USB-serial adapter and it does function correctly. However, I have not been able to test with OSVR, but I will be doing so soon.