### PR TITLE
Add display inputs and size to C++ API

### DIFF
--- a/inc/osvr/ClientKit/Display.h
+++ b/inc/osvr/ClientKit/Display.h
@@ -107,6 +107,11 @@ namespace clientkit {
         double bottom;
     };
 
+    struct DisplayDimensions {
+        OSVR_DisplayDimension width;
+        OSVR_DisplayDimension height;
+    };
+
     /// @brief Wrapper for a viewer, eye, and surface bound to a display config.
     /// DOES NOT provide lifetime management for the associated display config!
     class Surface {
@@ -453,6 +458,33 @@ namespace clientkit {
         bool checkStartup() const {
             ensureValid();
             return osvrClientCheckDisplayStartup(m_disp) == OSVR_RETURN_SUCCESS;
+        }
+
+        /// @brief Returns number of inputs for this display.
+        ///
+        /// @sa osvrClientGetNumDisplayInputs()
+        OSVR_DisplayInputCount getNumDisplayInputs() const {
+            ensureValid();
+            OSVR_DisplayInputCount inputs;
+            OSVR_ReturnCode ret = osvrClientGetNumDisplayInputs(m_disp, &inputs);
+            if (ret != OSVR_RETURN_SUCCESS) {
+                handleDisplayError("Couldn't get number of display inputs!");
+            }
+            return inputs;
+        }
+
+        /// @brief Returns display dimensions for a display input.
+        ///
+        /// @sa osvrClientGetDisplayDimensions()
+        osvr::clientkit::DisplayDimensions getDisplayDimensions(OSVR_DisplayInputCount displayInputIndex) const {
+            ensureValid();
+            DisplayDimensions dimensions;
+            OSVR_ReturnCode ret = osvrClientGetDisplayDimensions(m_disp, displayInputIndex, &dimensions.width, &dimensions.height);
+            if (ret != OSVR_RETURN_SUCCESS) {
+                handleDisplayError("Couldn't get dimensions of this "
+                                   "display!");
+            }
+            return dimensions;
         }
 
         /// @name Child-related methods


### PR DESCRIPTION
This adds display input access to the C++ API (it is currently only in the C API).