### PR TITLE
Rendermanager config

### DIFF
--- a/apps/sample-configs/osvr_server_config.renderManager.sample.json
+++ b/apps/sample-configs/osvr_server_config.renderManager.sample.json
@@ -1,0 +1,89 @@
+{
+	"renderManagerConfig": {
+		"meta": {
+			"schemaVersion": 1
+		},
+		"renderManagerConfig": {
+			"directModeEnabled": false,
+			"directDisplayIndex": 0,
+			"directHighPriorityEnabled": true,
+			"numBuffers": 2,
+			"verticalSyncEnabled": false,
+			"verticalSyncBlockRenderingEnabled": false,
+			"renderOverfillFactor": 2.0,
+			
+			"window": {
+				"title": "OSVR",
+				"fullScreenEnabled": true,
+				"xPosition": 1920,
+				"yPosition": 0
+			},
+
+			"display": {
+				"rotation": 90,
+				"bitsPerColor": 8
+			},
+
+			"timeWarp": {
+				"enabled": true,
+				"asynchronous": false,
+				"maxMsBeforeVSync": 3
+			}
+		}
+	},
+
+	"display": {
+		"meta": {
+			"schemaVersion": 1
+		},
+		"hmd": {
+			"device": {
+				"properties": {
+					"vendor": "OSVR",
+					"model": "HDK",
+					"num_displays": 1,
+					"Version": "1.1",
+					"Note": "OSVR HDK on screen in landscape mode"
+				}
+			},
+			"field_of_view": {
+				"monocular_horizontal": 90,
+				"monocular_vertical": 101.25,
+				"overlap_percent": 100,
+				"pitch_tilt": 0
+			},
+			"resolutions": [
+				{
+				"width": 1920,
+				"height": 1080,
+				"video_inputs": 1,
+				"display_mode": "horz_side_by_side",
+				"swap_eyes": 0
+				}
+			],
+			"distortion": {
+				"distance_scale_x": 1,
+				"distance_scale_y": 1,
+				"polynomial_coeffs_red": [ 0, 1 ],
+				"polynomial_coeffs_green": [ 0, 1 ],
+				"polynomial_coeffs_blue": [ 0, 1 ]
+			},
+			"rendering": {
+				"right_roll": 0,
+				"left_roll": 0
+			},
+			"eyes": [
+				{
+				"center_proj_x": 0.5,
+				"center_proj_y": 0.5,
+				"rotate_180": 0
+				},
+				{
+				"center_proj_x": 0.5,
+				"center_proj_y": 0.5,
+				"rotate_180": 0
+				}
+			]
+			}
+		}
+}

--- a/inc/osvr/Client/RenderManagerConfig.h
+++ b/inc/osvr/Client/RenderManagerConfig.h
@@ -26,10 +26,13 @@
 #ifndef INCLUDED_RenderManagerConfig_h_GUID_C8DA5781_5B6C_454A_B4FF_1DB50CBE3479
 #define INCLUDED_RenderManagerConfig_h_GUID_C8DA5781_5B6C_454A_B4FF_1DB50CBE3479
 
-// Required for DLL linkage on Windows
+// Internal Includes
 #include <osvr/Client/Export.h>
 #include <osvr/Util/UniquePtr.h>
 #include <osvr/Util/ClientOpaqueTypesC.h>
+
+// Library/third-party includes
+// - none
 
 // Standard includes
 #include <string>
@@ -41,56 +44,56 @@ namespace osvr {
 namespace client {
 
     class RenderManagerConfig;
-    typedef unique_ptr<RenderManagerConfig> RenderManagerConfigPtr;
+    typedef std::shared_ptr<RenderManagerConfig> RenderManagerConfigPtr;
     class RenderManagerConfigFactory {
     public:
         OSVR_CLIENT_EXPORT static RenderManagerConfigPtr
-            create(OSVR_ClientContext ctx);
+            createShared(OSVR_ClientContext ctx);
     };
 
     class RenderManagerConfig {
     public:
-        OSVR_CLIENT_EXPORT RenderManagerConfig(const std::string& render_manager_config);
+        OSVR_CLIENT_EXPORT RenderManagerConfig(const std::string& renderManagerConfig);
         OSVR_CLIENT_EXPORT RenderManagerConfig() {};
 
-        void OSVR_CLIENT_EXPORT parse(const std::string& render_manager_config);
-        void OSVR_CLIENT_EXPORT print() const;
+        OSVR_CLIENT_EXPORT void parse(const std::string& renderManagerConfig);
+        OSVR_CLIENT_EXPORT void print() const;
 
         /// Read the property information.
-        bool OSVR_CLIENT_EXPORT getDirectMode() const;
-        unsigned OSVR_CLIENT_EXPORT getDisplayIndex() const;
-        bool OSVR_CLIENT_EXPORT getDirectHighPriority() const;
+        OSVR_CLIENT_EXPORT bool getDirectMode() const;
+        OSVR_CLIENT_EXPORT uint32_t getDisplayIndex() const;
+        OSVR_CLIENT_EXPORT bool getDirectHighPriority() const;
 
-        bool OSVR_CLIENT_EXPORT getEnableTimeWarp() const;
-        bool OSVR_CLIENT_EXPORT getAsynchronousTimeWarp() const;
-        float OSVR_CLIENT_EXPORT getMaxMSBeforeVsyncTimeWarp() const;
-        float OSVR_CLIENT_EXPORT getRenderOverfillFactor() const;
+        OSVR_CLIENT_EXPORT bool getEnableTimeWarp() const;
+        OSVR_CLIENT_EXPORT bool getAsynchronousTimeWarp() const;
+        OSVR_CLIENT_EXPORT float getMaxMSBeforeVsyncTimeWarp() const;
+        OSVR_CLIENT_EXPORT float getRenderOverfillFactor() const;
 
-        unsigned OSVR_CLIENT_EXPORT getNumBuffers() const;
-        bool OSVR_CLIENT_EXPORT getVerticalSync() const;
-        bool OSVR_CLIENT_EXPORT getVerticalSyncBlockRendering() const;
+        OSVR_CLIENT_EXPORT std::size_t getNumBuffers() const;
+        OSVR_CLIENT_EXPORT bool getVerticalSync() const;
+        OSVR_CLIENT_EXPORT bool getVerticalSyncBlockRendering() const;
 
-        std::string OSVR_CLIENT_EXPORT getWindowTitle() const;
-        bool OSVR_CLIENT_EXPORT getWindowFullScreen() const;
-        int OSVR_CLIENT_EXPORT getWindowXPosition() const;
-        int OSVR_CLIENT_EXPORT getWindowYPosition() const;
-        unsigned OSVR_CLIENT_EXPORT getDisplayRotation() const;
-        unsigned OSVR_CLIENT_EXPORT getBitsPerColor() const;
+        OSVR_CLIENT_EXPORT std::string getWindowTitle() const;
+        OSVR_CLIENT_EXPORT bool getWindowFullScreen() const;
+        OSVR_CLIENT_EXPORT int32_t getWindowXPosition() const;
+        OSVR_CLIENT_EXPORT int32_t getWindowYPosition() const;
+        OSVR_CLIENT_EXPORT uint32_t getDisplayRotation() const;
+        OSVR_CLIENT_EXPORT uint32_t getBitsPerColor() const;
 
     private:
         bool m_directMode;
-        unsigned m_displayIndex;
+        uint32_t m_displayIndex;
         bool m_directHighPriority;
-        unsigned m_numBuffers;
+        std::size_t m_numBuffers;
         bool m_verticalSync;
         bool m_verticalSyncBlockRendering;
 
         std::string m_windowTitle;
         bool m_windowFullScreen;
-        int m_windowXPosition;
-        int m_windowYPosition;
-        unsigned m_displayRotation;
-        unsigned m_bitsPerColor;
+        int32_t m_windowXPosition;
+        int32_t m_windowYPosition;
+        uint32_t m_displayRotation;
+        uint32_t m_bitsPerColor;
 
         bool m_enableTimeWarp;
         bool m_asynchronousTimeWarp;

--- a/inc/osvr/Client/RenderManagerConfig.h
+++ b/inc/osvr/Client/RenderManagerConfig.h
@@ -40,22 +40,6 @@
 namespace osvr {
 namespace client {
 
-    class RenderManagerConfigParseException : public std::exception {
-    public:
-        OSVR_CLIENT_EXPORT RenderManagerConfigParseException(const std::string& message) /*OSVR_NOEXCEPT*/ : std::exception(), m_message(message)
-        {
-            // do nothing
-        }
-
-        virtual const char OSVR_CLIENT_EXPORT *what() const /*OSVR_NOEXCEPT OSVR_OVERRIDE*/
-        {
-            return m_message.c_str();
-        }
-
-    private:
-        const std::string m_message;
-    };
-
     class RenderManagerConfig;
     typedef unique_ptr<RenderManagerConfig> RenderManagerConfigPtr;
     class RenderManagerConfigFactory {

--- a/inc/osvr/Client/RenderManagerConfig.h
+++ b/inc/osvr/Client/RenderManagerConfig.h
@@ -1,0 +1,110 @@
+/** @file
+    @brief OSVR rendermanager configuration
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+    */
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_RenderManagerConfig_h_GUID_C8DA5781_5B6C_454A_B4FF_1DB50CBE3479
+#define INCLUDED_RenderManagerConfig_h_GUID_C8DA5781_5B6C_454A_B4FF_1DB50CBE3479
+
+// Required for DLL linkage on Windows
+#include <osvr/Client/Export.h>
+
+// Standard includes
+#include <string>
+#include <iostream>
+#include <exception>
+#include <vector>
+
+namespace osvr {
+namespace client {
+
+    class RenderManagerConfigParseException : public std::exception {
+    public:
+        OSVR_CLIENT_EXPORT RenderManagerConfigParseException(const std::string& message) /*OSVR_NOEXCEPT*/ : std::exception(), m_message(message)
+        {
+            // do nothing
+        }
+
+        virtual const char OSVR_CLIENT_EXPORT *what() const /*OSVR_NOEXCEPT OSVR_OVERRIDE*/
+        {
+            return m_message.c_str();
+        }
+
+    private:
+        const std::string m_message;
+    };
+
+    class RenderManagerConfig {
+    public:
+        OSVR_CLIENT_EXPORT RenderManagerConfig(const std::string& render_manager_config);
+        OSVR_CLIENT_EXPORT RenderManagerConfig() {};
+
+        void OSVR_CLIENT_EXPORT parse(const std::string& render_manager_config);
+        void OSVR_CLIENT_EXPORT print() const;
+
+        /// Read the property information.
+        bool OSVR_CLIENT_EXPORT getDirectMode() const;
+        unsigned OSVR_CLIENT_EXPORT getDisplayIndex() const;
+        bool OSVR_CLIENT_EXPORT getDirectHighPriority() const;
+
+        bool OSVR_CLIENT_EXPORT getEnableTimeWarp() const;
+        bool OSVR_CLIENT_EXPORT getAsynchronousTimeWarp() const;
+        float OSVR_CLIENT_EXPORT getMaxMSBeforeVsyncTimeWarp() const;
+        float OSVR_CLIENT_EXPORT getRenderOverfillFactor() const;
+
+        unsigned OSVR_CLIENT_EXPORT getNumBuffers() const;
+        bool OSVR_CLIENT_EXPORT getVerticalSync() const;
+        bool OSVR_CLIENT_EXPORT getVerticalSyncBlockRendering() const;
+
+        std::string OSVR_CLIENT_EXPORT getWindowTitle() const;
+        bool OSVR_CLIENT_EXPORT getWindowFullScreen() const;
+        int OSVR_CLIENT_EXPORT getWindowXPosition() const;
+        int OSVR_CLIENT_EXPORT getWindowYPosition() const;
+        unsigned OSVR_CLIENT_EXPORT getDisplayRotation() const;
+        unsigned OSVR_CLIENT_EXPORT getBitsPerColor() const;
+
+    private:
+        bool m_directMode;
+        unsigned m_displayIndex;
+        bool m_directHighPriority;
+        unsigned m_numBuffers;
+        bool m_verticalSync;
+        bool m_verticalSyncBlockRendering;
+
+        std::string m_windowTitle;
+        bool m_windowFullScreen;
+        int m_windowXPosition;
+        int m_windowYPosition;
+        unsigned m_displayRotation;
+        unsigned m_bitsPerColor;
+
+        bool m_enableTimeWarp;
+        bool m_asynchronousTimeWarp;
+        float m_maxMSBeforeVsyncTimeWarp;
+        float m_renderOverfillFactor;
+    };
+
+} // namespace client
+} // namespace osvr
+
+#endif // INCLUDED_RenderManagerConfig_h_GUID_C8DA5781_5B6C_454A_B4FF_1DB50CBE3479

--- a/inc/osvr/Client/RenderManagerConfig.h
+++ b/inc/osvr/Client/RenderManagerConfig.h
@@ -28,6 +28,8 @@
 
 // Required for DLL linkage on Windows
 #include <osvr/Client/Export.h>
+#include <osvr/Util/UniquePtr.h>
+#include <osvr/Util/ClientOpaqueTypesC.h>
 
 // Standard includes
 #include <string>
@@ -52,6 +54,14 @@ namespace client {
 
     private:
         const std::string m_message;
+    };
+
+    class RenderManagerConfig;
+    typedef unique_ptr<RenderManagerConfig> RenderManagerConfigPtr;
+    class RenderManagerConfigFactory {
+    public:
+        OSVR_CLIENT_EXPORT static RenderManagerConfigPtr
+            create(OSVR_ClientContext ctx);
     };
 
     class RenderManagerConfig {

--- a/inc/osvr/Server/ConfigureServer.h
+++ b/inc/osvr/Server/ConfigureServer.h
@@ -151,6 +151,10 @@ namespace server {
         /// @return true if one was found and it was successfully loaded.
         OSVR_SERVER_EXPORT bool processDisplay();
 
+        /// @brief Process a RenderManager config element in the config.
+        /// @return true if one was found and it was successfully loaded.
+        OSVR_SERVER_EXPORT bool processRenderManagerParameters();
+
         /// @brief Loads all plugins not marked for manual load.
         OSVR_SERVER_EXPORT void loadAutoPlugins();
 

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -159,6 +159,11 @@ namespace server {
                    "may use the OSVR HDK as a default." << endl;
         }
 
+        if (srvConfig.processRenderManagerParameters()) {
+            out << "RenderManager config found and parsed from the config file"
+                << endl;
+        }
+
         out << "Triggering a hardware detection..." << endl;
         ret->triggerHardwareDetect();
 

--- a/src/osvr/Client/CMakeLists.txt
+++ b/src/osvr/Client/CMakeLists.txt
@@ -10,6 +10,7 @@ set(API
     "${HEADER_LOCATION}/InterfaceTree.h"
     "${HEADER_LOCATION}/RemoteHandler.h"
     "${HEADER_LOCATION}/RemoteHandlerFactory.h"
+    "${HEADER_LOCATION}/RenderManagerConfig.h"
     "${HEADER_LOCATION}/Viewer.h"
     "${HEADER_LOCATION}/Viewers.h"
     "${HEADER_LOCATION}/ViewerEye.h"
@@ -43,6 +44,7 @@ set(SOURCE
     PureClientContext.h
     RemoteHandler.cpp
     RemoteHandlerFactory.cpp
+    RenderManagerConfig.cpp
     RouterPredicates.h
     RouterTransforms.h
     TrackerRemoteFactory.cpp

--- a/src/osvr/Client/RenderManagerConfig.cpp
+++ b/src/osvr/Client/RenderManagerConfig.cpp
@@ -25,6 +25,8 @@
 
 // Internal Includes
 #include <osvr/Client/RenderManagerConfig.h>
+#include <osvr/Common/ClientContext.h>
+#include <osvr/Util/Verbosity.h>
 
 // Library/third-party includes
 #include <json/value.h>
@@ -32,137 +34,157 @@
 
 namespace osvr {
 namespace client {
-RenderManagerConfig::RenderManagerConfig(const std::string& render_manager_config)
-{
-    parse(render_manager_config);
-}
 
-void RenderManagerConfig::parse(const std::string& render_manager_config)
-{
-  Json::Reader reader;
-  Json::Value root;
-  reader.parse(render_manager_config, root, false);
+    RenderManagerConfigPtr RenderManagerConfigFactory::create(OSVR_ClientContext ctx) {
+        try {
+            auto const configString = ctx->getStringParameter("/display");
+            RenderManagerConfigPtr cfg(new RenderManagerConfig(configString));
+            return cfg;
+        }
+        catch (std::exception const &e) {
+            OSVR_DEV_VERBOSE(
+                "Couldn't create a render manager config internally! Exception: "
+                << e.what());
+            return RenderManagerConfigPtr{};
+        }
+        catch (...) {
+            OSVR_DEV_VERBOSE("Couldn't create a display config internally! "
+                "Unknown exception!");
+            return RenderManagerConfigPtr{};
+        }
+    }
 
-  m_directMode = root["render_manager_parameters"]["direct_mode"].asBool();
-  m_displayIndex = root["render_manager_parameters"]["direct_display_index"].asUInt();
-  m_directHighPriority = root["render_manager_parameters"]["direct_high_priority"].asBool();
+    RenderManagerConfig::RenderManagerConfig(const std::string& render_manager_config)
+    {
+        parse(render_manager_config);
+    }
 
-  m_numBuffers = root["render_manager_parameters"]["num_buffers"].asUInt();
-  m_verticalSync = root["render_manager_parameters"]["vertical_sync"].asBool();
-  m_verticalSyncBlockRendering = root["render_manager_parameters"]
-    ["vertical_sync_block_rendering"].asBool();
-  m_windowTitle = root["render_manager_parameters"]["window_title"].asString();
-  m_windowFullScreen = root["render_manager_parameters"]["window_full_screen"].asBool();
-  m_windowXPosition = root["render_manager_parameters"]["window_x_position"].asInt();
-  m_windowYPosition = root["render_manager_parameters"]["window_y_position"].asInt();
-  m_displayRotation = root["render_manager_parameters"]["display_rotation"].asUInt();
-  m_bitsPerColor = root["render_manager_parameters"]["bits_per_color"].asBool();
+    void RenderManagerConfig::parse(const std::string& render_manager_config)
+    {
+      Json::Reader reader;
+      Json::Value root;
+      reader.parse(render_manager_config, root, false);
 
-  m_enableTimeWarp = root["render_manager_parameters"]["time_warp"]["enable"].asBool();
-  m_asynchronousTimeWarp = root["render_manager_parameters"]["time_warp"]["asynchronous_time_warp"].asBool();
-  m_maxMSBeforeVsyncTimeWarp = root["render_manager_parameters"]["time_warp"]["max_ms_before_vsync"].asFloat();
+      m_directMode = root["render_manager_parameters"]["direct_mode"].asBool();
+      m_displayIndex = root["render_manager_parameters"]["direct_display_index"].asUInt();
+      m_directHighPriority = root["render_manager_parameters"]["direct_high_priority"].asBool();
+
+      m_numBuffers = root["render_manager_parameters"]["num_buffers"].asUInt();
+      m_verticalSync = root["render_manager_parameters"]["vertical_sync"].asBool();
+      m_verticalSyncBlockRendering = root["render_manager_parameters"]
+        ["vertical_sync_block_rendering"].asBool();
+      m_windowTitle = root["render_manager_parameters"]["window_title"].asString();
+      m_windowFullScreen = root["render_manager_parameters"]["window_full_screen"].asBool();
+      m_windowXPosition = root["render_manager_parameters"]["window_x_position"].asInt();
+      m_windowYPosition = root["render_manager_parameters"]["window_y_position"].asInt();
+      m_displayRotation = root["render_manager_parameters"]["display_rotation"].asUInt();
+      m_bitsPerColor = root["render_manager_parameters"]["bits_per_color"].asBool();
+
+      m_enableTimeWarp = root["render_manager_parameters"]["time_warp"]["enable"].asBool();
+      m_asynchronousTimeWarp = root["render_manager_parameters"]["time_warp"]["asynchronous_time_warp"].asBool();
+      m_maxMSBeforeVsyncTimeWarp = root["render_manager_parameters"]["time_warp"]["max_ms_before_vsync"].asFloat();
  
-  m_renderOverfillFactor = root["render_manager_parameters"]["render_overfill_factor"].asFloat();
-}
+      m_renderOverfillFactor = root["render_manager_parameters"]["render_overfill_factor"].asFloat();
+    }
 
-void RenderManagerConfig::print() const
-{
-  std::cout << "Direct mode: " << m_directMode << std::endl;
-  std::cout << "Direct mode display index: " << m_displayIndex << std::endl;
-  std::cout << "Number of buffers: " << m_numBuffers << std::endl;
-  std::cout << "Vertical sync: " << m_verticalSync << std::endl;
-  std::cout << "Vertical sync block rendering: " << m_verticalSyncBlockRendering << std::endl;
-  std::cout << "Window Title: " << m_windowTitle << std::endl;
-  std::cout << "Window full screen: " << m_windowFullScreen << std::endl;
-  std::cout << "Window X Position: " << m_windowXPosition << std::endl;
-  std::cout << "Window Y Position: " << m_windowYPosition << std::endl;
-  std::cout << "Display rotation: " << m_displayRotation << std::endl;
-  std::cout << "Bits per color: " << m_bitsPerColor << std::endl;
-  std::cout << "Enable time warp: " << m_enableTimeWarp << std::endl;
-  std::cout << "Asynchronous time warp: " << m_asynchronousTimeWarp << std::endl;
-  std::cout << "Max ms before vsync time warp: " << m_maxMSBeforeVsyncTimeWarp << std::endl;
-  std::cout << "Render overfill factor: " << m_renderOverfillFactor << std::endl;
-}
+    void RenderManagerConfig::print() const
+    {
+      std::cout << "Direct mode: " << m_directMode << std::endl;
+      std::cout << "Direct mode display index: " << m_displayIndex << std::endl;
+      std::cout << "Number of buffers: " << m_numBuffers << std::endl;
+      std::cout << "Vertical sync: " << m_verticalSync << std::endl;
+      std::cout << "Vertical sync block rendering: " << m_verticalSyncBlockRendering << std::endl;
+      std::cout << "Window Title: " << m_windowTitle << std::endl;
+      std::cout << "Window full screen: " << m_windowFullScreen << std::endl;
+      std::cout << "Window X Position: " << m_windowXPosition << std::endl;
+      std::cout << "Window Y Position: " << m_windowYPosition << std::endl;
+      std::cout << "Display rotation: " << m_displayRotation << std::endl;
+      std::cout << "Bits per color: " << m_bitsPerColor << std::endl;
+      std::cout << "Enable time warp: " << m_enableTimeWarp << std::endl;
+      std::cout << "Asynchronous time warp: " << m_asynchronousTimeWarp << std::endl;
+      std::cout << "Max ms before vsync time warp: " << m_maxMSBeforeVsyncTimeWarp << std::endl;
+      std::cout << "Render overfill factor: " << m_renderOverfillFactor << std::endl;
+    }
 
-bool RenderManagerConfig::getDirectMode() const
-{
-  return m_directMode;
-}
+    bool RenderManagerConfig::getDirectMode() const
+    {
+      return m_directMode;
+    }
 
-unsigned RenderManagerConfig::getDisplayIndex() const
-{
-  return m_displayIndex;
-}
+    unsigned RenderManagerConfig::getDisplayIndex() const
+    {
+      return m_displayIndex;
+    }
 
-bool RenderManagerConfig::getDirectHighPriority() const
-{
-  return m_directHighPriority;
-}
+    bool RenderManagerConfig::getDirectHighPriority() const
+    {
+      return m_directHighPriority;
+    }
 
-unsigned RenderManagerConfig::getNumBuffers() const
-{
-  return m_numBuffers;
-}
+    unsigned RenderManagerConfig::getNumBuffers() const
+    {
+      return m_numBuffers;
+    }
 
-bool RenderManagerConfig::getVerticalSync() const
-{
-  return m_verticalSync;
-}
+    bool RenderManagerConfig::getVerticalSync() const
+    {
+      return m_verticalSync;
+    }
 
-bool RenderManagerConfig::getVerticalSyncBlockRendering() const
-{
-  return m_verticalSyncBlockRendering;
-}
+    bool RenderManagerConfig::getVerticalSyncBlockRendering() const
+    {
+      return m_verticalSyncBlockRendering;
+    }
 
-std::string RenderManagerConfig::getWindowTitle() const
-{
-  return m_windowTitle;
-}
+    std::string RenderManagerConfig::getWindowTitle() const
+    {
+      return m_windowTitle;
+    }
 
-bool RenderManagerConfig::getWindowFullScreen() const
-{
-  return m_windowFullScreen;
-}
+    bool RenderManagerConfig::getWindowFullScreen() const
+    {
+      return m_windowFullScreen;
+    }
 
-int RenderManagerConfig::getWindowXPosition() const
-{
-  return m_windowXPosition;
-}
+    int RenderManagerConfig::getWindowXPosition() const
+    {
+      return m_windowXPosition;
+    }
 
-int RenderManagerConfig::getWindowYPosition() const
-{
-  return m_windowYPosition;
-}
+    int RenderManagerConfig::getWindowYPosition() const
+    {
+      return m_windowYPosition;
+    }
 
-unsigned RenderManagerConfig::getDisplayRotation() const
-{
-  return m_displayRotation;
-}
+    unsigned RenderManagerConfig::getDisplayRotation() const
+    {
+      return m_displayRotation;
+    }
 
-unsigned RenderManagerConfig::getBitsPerColor() const
-{
-  return m_bitsPerColor;
-}
+    unsigned RenderManagerConfig::getBitsPerColor() const
+    {
+      return m_bitsPerColor;
+    }
 
-bool RenderManagerConfig::getEnableTimeWarp() const
-{
-  return m_enableTimeWarp;
-}
+    bool RenderManagerConfig::getEnableTimeWarp() const
+    {
+      return m_enableTimeWarp;
+    }
 
-bool RenderManagerConfig::getAsynchronousTimeWarp() const
-{
-  return m_asynchronousTimeWarp;
-}
+    bool RenderManagerConfig::getAsynchronousTimeWarp() const
+    {
+      return m_asynchronousTimeWarp;
+    }
 
-float RenderManagerConfig::getMaxMSBeforeVsyncTimeWarp() const
-{
-  return m_maxMSBeforeVsyncTimeWarp;
-}
+    float RenderManagerConfig::getMaxMSBeforeVsyncTimeWarp() const
+    {
+      return m_maxMSBeforeVsyncTimeWarp;
+    }
 
-float RenderManagerConfig::getRenderOverfillFactor() const
-{
-  return m_renderOverfillFactor;
-}
+    float RenderManagerConfig::getRenderOverfillFactor() const
+    {
+      return m_renderOverfillFactor;
+    }
 
 } // namespace client
 } // namespace osvr

--- a/src/osvr/Client/RenderManagerConfig.cpp
+++ b/src/osvr/Client/RenderManagerConfig.cpp
@@ -1,0 +1,168 @@
+/** @file
+    @brief OSVR rendermanager configuration
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Client/RenderManagerConfig.h>
+
+// Library/third-party includes
+#include <json/value.h>
+#include <json/reader.h>
+
+namespace osvr {
+namespace client {
+RenderManagerConfig::RenderManagerConfig(const std::string& render_manager_config)
+{
+    parse(render_manager_config);
+}
+
+void RenderManagerConfig::parse(const std::string& render_manager_config)
+{
+  Json::Reader reader;
+  Json::Value root;
+  reader.parse(render_manager_config, root, false);
+
+  m_directMode = root["render_manager_parameters"]["direct_mode"].asBool();
+  m_displayIndex = root["render_manager_parameters"]["direct_display_index"].asUInt();
+  m_directHighPriority = root["render_manager_parameters"]["direct_high_priority"].asBool();
+
+  m_numBuffers = root["render_manager_parameters"]["num_buffers"].asUInt();
+  m_verticalSync = root["render_manager_parameters"]["vertical_sync"].asBool();
+  m_verticalSyncBlockRendering = root["render_manager_parameters"]
+    ["vertical_sync_block_rendering"].asBool();
+  m_windowTitle = root["render_manager_parameters"]["window_title"].asString();
+  m_windowFullScreen = root["render_manager_parameters"]["window_full_screen"].asBool();
+  m_windowXPosition = root["render_manager_parameters"]["window_x_position"].asInt();
+  m_windowYPosition = root["render_manager_parameters"]["window_y_position"].asInt();
+  m_displayRotation = root["render_manager_parameters"]["display_rotation"].asUInt();
+  m_bitsPerColor = root["render_manager_parameters"]["bits_per_color"].asBool();
+
+  m_enableTimeWarp = root["render_manager_parameters"]["time_warp"]["enable"].asBool();
+  m_asynchronousTimeWarp = root["render_manager_parameters"]["time_warp"]["asynchronous_time_warp"].asBool();
+  m_maxMSBeforeVsyncTimeWarp = root["render_manager_parameters"]["time_warp"]["max_ms_before_vsync"].asFloat();
+ 
+  m_renderOverfillFactor = root["render_manager_parameters"]["render_overfill_factor"].asFloat();
+}
+
+void RenderManagerConfig::print() const
+{
+  std::cout << "Direct mode: " << m_directMode << std::endl;
+  std::cout << "Direct mode display index: " << m_displayIndex << std::endl;
+  std::cout << "Number of buffers: " << m_numBuffers << std::endl;
+  std::cout << "Vertical sync: " << m_verticalSync << std::endl;
+  std::cout << "Vertical sync block rendering: " << m_verticalSyncBlockRendering << std::endl;
+  std::cout << "Window Title: " << m_windowTitle << std::endl;
+  std::cout << "Window full screen: " << m_windowFullScreen << std::endl;
+  std::cout << "Window X Position: " << m_windowXPosition << std::endl;
+  std::cout << "Window Y Position: " << m_windowYPosition << std::endl;
+  std::cout << "Display rotation: " << m_displayRotation << std::endl;
+  std::cout << "Bits per color: " << m_bitsPerColor << std::endl;
+  std::cout << "Enable time warp: " << m_enableTimeWarp << std::endl;
+  std::cout << "Asynchronous time warp: " << m_asynchronousTimeWarp << std::endl;
+  std::cout << "Max ms before vsync time warp: " << m_maxMSBeforeVsyncTimeWarp << std::endl;
+  std::cout << "Render overfill factor: " << m_renderOverfillFactor << std::endl;
+}
+
+bool RenderManagerConfig::getDirectMode() const
+{
+  return m_directMode;
+}
+
+unsigned RenderManagerConfig::getDisplayIndex() const
+{
+  return m_displayIndex;
+}
+
+bool RenderManagerConfig::getDirectHighPriority() const
+{
+  return m_directHighPriority;
+}
+
+unsigned RenderManagerConfig::getNumBuffers() const
+{
+  return m_numBuffers;
+}
+
+bool RenderManagerConfig::getVerticalSync() const
+{
+  return m_verticalSync;
+}
+
+bool RenderManagerConfig::getVerticalSyncBlockRendering() const
+{
+  return m_verticalSyncBlockRendering;
+}
+
+std::string RenderManagerConfig::getWindowTitle() const
+{
+  return m_windowTitle;
+}
+
+bool RenderManagerConfig::getWindowFullScreen() const
+{
+  return m_windowFullScreen;
+}
+
+int RenderManagerConfig::getWindowXPosition() const
+{
+  return m_windowXPosition;
+}
+
+int RenderManagerConfig::getWindowYPosition() const
+{
+  return m_windowYPosition;
+}
+
+unsigned RenderManagerConfig::getDisplayRotation() const
+{
+  return m_displayRotation;
+}
+
+unsigned RenderManagerConfig::getBitsPerColor() const
+{
+  return m_bitsPerColor;
+}
+
+bool RenderManagerConfig::getEnableTimeWarp() const
+{
+  return m_enableTimeWarp;
+}
+
+bool RenderManagerConfig::getAsynchronousTimeWarp() const
+{
+  return m_asynchronousTimeWarp;
+}
+
+float RenderManagerConfig::getMaxMSBeforeVsyncTimeWarp() const
+{
+  return m_maxMSBeforeVsyncTimeWarp;
+}
+
+float RenderManagerConfig::getRenderOverfillFactor() const
+{
+  return m_renderOverfillFactor;
+}
+
+} // namespace client
+} // namespace osvr

--- a/src/osvr/Server/ConfigureServer.cpp
+++ b/src/osvr/Server/ConfigureServer.cpp
@@ -352,6 +352,29 @@ namespace server {
         return success;
     }
 
+    static const char RENDERMANAGER_KEY[] = "render_manager_parameters";
+    static const char RENDERMANAGER_PATH[] = "/render_manager_parameters";
+    bool ConfigureServer::processRenderManagerParameters() {
+        bool success = false;
+        Json::Value const &renderManager = m_data->getMember(RENDERMANAGER_KEY);
+        if (renderManager.isNull()) {
+            return success;
+        }
+
+        auto result = resolvePossibleRef(renderManager);
+        if (result.isNull()) {
+            OSVR_DEV_VERBOSE(
+                "ERROR: Could not load an object or render manager config "
+                "file specified by: "
+                << renderManager.toStyledString());
+            return success;
+        }
+
+        // OK, got it
+        success = m_server->addString(RENDERMANAGER_PATH, result.toStyledString());
+        return success;
+    }
+
     void ConfigureServer::loadAutoPlugins() { m_server->loadAutoPlugins(); }
 
 } // namespace server

--- a/src/osvr/Server/ConfigureServer.cpp
+++ b/src/osvr/Server/ConfigureServer.cpp
@@ -352,8 +352,8 @@ namespace server {
         return success;
     }
 
-    static const char RENDERMANAGER_KEY[] = "render_manager_parameters";
-    static const char RENDERMANAGER_PATH[] = "/render_manager_parameters";
+    static const char RENDERMANAGER_KEY[] = "renderManagerConfig";
+    static const char RENDERMANAGER_PATH[] = "/renderManagerConfig";
     bool ConfigureServer::processRenderManagerParameters() {
         bool success = false;
         Json::Value const &renderManager = m_data->getMember(RENDERMANAGER_KEY);


### PR DESCRIPTION
Adding RenderManagerConfig parsing and server string to osvrClient as an internal API. It will be used directly by the RenderManager API.