### PR TITLE
Automatically find config data or load default

### DIFF
--- a/apps/osvr_server.cpp
+++ b/apps/osvr_server.cpp
@@ -26,6 +26,7 @@
 // Internal Includes
 #include <osvr/Server/ConfigureServerFromFile.h>
 #include <osvr/Server/RegisterShutdownHandler.h>
+#include <osvr/Server/ConfigFilePaths.h>
 
 // Library/third-party includes
 // - none
@@ -49,16 +50,20 @@ void handleShutdown() {
 }
 
 int main(int argc, char *argv[]) {
-    std::vector<std::string> configNames;
+    std::vector<std::string> configPaths;
     if (argc > 1) {
-        configNames = {std::string(argv[1])};
+        configPaths = {std::string(argv[1])};
     } else {
         out << "Using default config files - pass a filename on the command "
                "line to use a different one." << endl;
-        configNames = osvr::server::getDefaultConfigFilenames();
+        configPaths = osvr::server::getDefaultConfigFilePaths();
     }
 
-    server = osvr::server::configureServerFromFirstFileInList(configNames);
+    server = osvr::server::configureServerFromFirstFileInList(configPaths);
+    if (!server) {
+        out << "Using default config data." << endl;
+        server = osvr::server::configureServerFromFile("");
+    }
     if (!server) {
         return -1;
     }

--- a/apps/osvr_server.cpp
+++ b/apps/osvr_server.cpp
@@ -55,7 +55,8 @@ int main(int argc, char *argv[]) {
         configPaths = {std::string(argv[1])};
     } else {
         out << "Using default config files - pass a filename on the command "
-               "line to use a different one." << endl;
+               "line to use a different one."
+            << endl;
         configPaths = osvr::server::getDefaultConfigFilePaths();
     }
 

--- a/apps/osvr_server.cpp
+++ b/apps/osvr_server.cpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <fstream>
 #include <exception>
+#include <vector>
 
 using osvr::server::detail::out;
 using osvr::server::detail::err;
@@ -48,15 +49,16 @@ void handleShutdown() {
 }
 
 int main(int argc, char *argv[]) {
-    std::string configName(osvr::server::getDefaultConfigFilename());
+    std::vector<std::string> configNames;
     if (argc > 1) {
-        configName = argv[1];
+        configNames = {std::string(argv[1])};
     } else {
-        out << "Using default config file - pass a filename on the command "
+        out << "Using default config files - pass a filename on the command "
                "line to use a different one." << endl;
+        configNames = osvr::server::getDefaultConfigFilenames();
     }
 
-    server = osvr::server::configureServerFromFile(configName);
+    server = osvr::server::configureServerFromFirstFileInList(configNames);
     if (!server) {
         return -1;
     }

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -61,7 +61,8 @@ namespace server {
     /// @brief this returns a vector of default server configuration file paths.
     std::vector<std::string> getDefaultConfigFilePaths();
 
-    /// @brief This uses a file name to attempt to configure the server with that config file.
+    /// @brief This uses a file name to attempt to configure the server with
+    /// that config file.
     /// Pass an empty string to use the default config.
     /// This is the basic common code of a server app's setup, ripped out
     /// of the main server app to make alternate server-acting apps simpler to
@@ -69,8 +70,10 @@ namespace server {
     ServerPtr configureServerFromFile(std::string const &configName);
 
     /// @brief This iterates over a vector that contains a list of potential
-    /// config files, and uses the first working one to create the server instance.
-    ServerPtr configureServerFromFirstFileInList(std::vector<std::string> const &configNames);
+    /// config files, and uses the first working one to create the server
+    /// instance.
+    ServerPtr configureServerFromFirstFileInList(
+        std::vector<std::string> const &configNames);
 
 } // namespace server
 } // namespace osvr

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -58,150 +58,19 @@ namespace server {
         static detail::StreamPrefixer err("[OSVR Server] ", std::cerr);
     } // namespace detail
 
-    inline std::vector<std::string> getDefaultConfigFilenames() {
-        std::vector<std::string> names;
-        names.push_back("HOME/.osvr/osvr_server_config.json");
-        names.push_back("PREFIX/etc/osvr_server_config.json");
-#ifdef WINDOWS
-        names.push_back("osvr_server_config.json");
-#elif MAC
-        names.push_back("HOME/Library/Application Support/OSVR/osvr_server_config.json");
-#endif
-        for (auto i = names.begin(); i != names.end(); i++) {
-            std::cout << *i << std::endl;
-        }
+    /// @brief this returns a vector of default server configuration file paths.
+    std::vector<std::string> getDefaultConfigFilePaths();
 
-        return names;
-    }
-
-    /// @brief This is the basic common code of a server app's setup, ripped out
+    /// @brief This uses a file name to attempt to configure the server with that config file.
+    /// Pass an empty string to use the default config.
+    /// This is the basic common code of a server app's setup, ripped out
     /// of the main server app to make alternate server-acting apps simpler to
     /// develop.
+    ServerPtr configureServerFromFile(std::string const &configName);
 
-    inline ServerPtr configureServerFromFile(std::string const &configName) {
-        using detail::out;
-        using detail::err;
-        using std::endl;
-        ServerPtr ret;
-        out << "Using config file '" << configName << "'" << endl;
-        std::ifstream config(configName);
-        if (!config.good()) {
-            err << "\n"
-                << "Could not open config file!" << endl;
-            err << "Searched in the current directory; file may be "
-                   "misspelled, missing, or in a different directory." << endl;
-            return nullptr;
-        }
-
-        osvr::server::ConfigureServer srvConfig;
-        out << "Constructing server as configured..." << endl;
-        try {
-            srvConfig.loadConfig(config);
-            ret = srvConfig.constructServer();
-        } catch (std::exception &e) {
-            err << "Caught exception constructing server from JSON config "
-                   "file: " << e.what() << endl;
-            return nullptr;
-        }
-
-        {
-            out << "Loading auto-loadable plugins..." << endl;
-            srvConfig.loadAutoPlugins();
-        }
-
-        {
-            out << "Loading plugins..." << endl;
-            srvConfig.loadPlugins();
-            if (!srvConfig.getSuccessfulPlugins().empty()) {
-                out << "Successful plugins:" << endl;
-                for (auto const &plugin : srvConfig.getSuccessfulPlugins()) {
-                    out << " - " << plugin << endl;
-                }
-                out << "\n";
-            }
-            if (!srvConfig.getFailedPlugins().empty()) {
-                out << "Failed plugins:" << endl;
-                for (auto const &pluginError : srvConfig.getFailedPlugins()) {
-                    out << " - " << pluginError.first << "\t"
-                        << pluginError.second << endl;
-                }
-                out << "\n";
-            }
-
-            out << "\n";
-        }
-
-        {
-            out << "Instantiating configured drivers..." << endl;
-            bool success = srvConfig.instantiateDrivers();
-            if (!srvConfig.getSuccessfulInstantiations().empty()) {
-                out << "Successes:" << endl;
-                for (auto const &driver :
-                     srvConfig.getSuccessfulInstantiations()) {
-                    out << " - " << driver << endl;
-                }
-                out << "\n";
-            }
-            if (!srvConfig.getFailedInstantiations().empty()) {
-                out << "Errors:" << endl;
-                for (auto const &error : srvConfig.getFailedInstantiations()) {
-                    out << " - " << error.first << "\t" << error.second << endl;
-                }
-                out << "\n";
-            }
-            out << "\n";
-        }
-
-        if (srvConfig.processExternalDevices()) {
-            out << "External devices found and parsed from config file."
-                << endl;
-        }
-
-        if (srvConfig.processRoutes()) {
-            out << "Routes found and parsed from config file." << endl;
-        }
-
-        if (srvConfig.processAliases()) {
-            out << "Aliases found and parsed from config file." << endl;
-        }
-
-        if (srvConfig.processDisplay()) {
-            out << "Display descriptor found and parsed from config file"
-                << endl;
-        } else {
-            out << "No valid 'display' object found in config file - server "
-                   "may use the OSVR HDK as a default." << endl;
-        }
-
-        if (srvConfig.processRenderManagerParameters()) {
-            out << "RenderManager config found and parsed from the config file"
-                << endl;
-        }
-
-        out << "Triggering a hardware detection..." << endl;
-        ret->triggerHardwareDetect();
-
-        return ret;
-    }
-
-    inline ServerPtr configureServerFromFirstFileInList(std::vector<std::string> const &configNames) {
-        using detail::out;
-        using detail::err;
-        using std::endl;
-        for(const auto name: configNames) {
-            std::ifstream config(name);
-            if(config.good()) {
-                out << "Using config file '" << name << "'" << endl;
-                return configureServerFromFile(name);
-            }
-        }
-        err << "Could not open config file!" << endl;
-        err << "Attempted the following files:" << endl;
-        for (auto i = configNames.begin(); i != configNames.end(); i++) {
-            std::cout << *i << std::endl;
-        }
-        return nullptr;
-    }
+    /// @brief This iterates over a vector that contains a list of potential
+    /// config files, and uses the first working one to create the server instance.
+    ServerPtr configureServerFromFirstFileInList(std::vector<std::string> const &configNames);
 
 } // namespace server
 } // namespace osvr

--- a/src/osvr/Server/CMakeLists.txt
+++ b/src/osvr/Server/CMakeLists.txt
@@ -11,12 +11,15 @@ set(API
 
 set(SOURCE
     ConfigureServer.cpp
+    ConfigureServerFromFile.cpp
     JSONResolvePossibleRef.h
     JSONResolvePossibleRef.cpp
     Server.cpp
     ServerImpl.cpp
     ServerImpl.h
     "${CMAKE_CURRENT_BINARY_DIR}/display_json.h")
+
+configure_file(ConfigFilePaths.h.cmake_in "${CMAKE_CURRENT_BINARY_DIR}/ConfigFilePaths.h")
 
 # Fallback display descriptor
 set(DISPLAY_JSON ../../../apps/displays/OSVR_HDK_1_1.json)

--- a/src/osvr/Server/ConfigFilePaths.h.cmake_in
+++ b/src/osvr/Server/ConfigFilePaths.h.cmake_in
@@ -1,0 +1,55 @@
+/** @file
+    @brief Auto-generated configuration header - do not edit!
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_ConfigFilePaths_h_GUID_241E9C9C_0E0E_46B0_9DED_8F8059306192
+#define INCLUDED_ConfigFilePaths_h_GUID_241E9C9C_0E0E_46B0_9DED_8F8059306192
+
+#include <osvr/Util/PlatformConfig.h>
+namespace osvr {
+  namespace server {
+
+    std::vector<std::string> getDefaultConfigFilePaths() {
+
+#ifdef OSVR_WINDOWS
+        std::string appdata = std::getenv("APPDATA");
+#else
+        std::string home = std::getenv("HOME");
+#endif
+
+        std::vector<std::string> names;
+        names.push_back(home + "/.osvr/osvr_server_config.json");
+        names.push_back("@CMAKE_INSTALL_FULL_SYSCONFDIR@/osvr_server_config.json");
+
+#if defined(OSVR_WINDOWS)
+        names.push_back(appdata + "\\OSVR\\osvr_server_config.json");
+        names.push_back("osvr_server_config.json");
+#elif defined(OSVR_MACOSX)
+        names.push_back(home + "/Library/Application Support/OSVR/osvr_server_config.json");
+#endif
+
+        return names;
+    }
+  }
+}
+#endif // INCLUDED_ConfigFilePaths_h_GUID_241E9C9C_0E0E_46B0_9DED_8F8059306192

--- a/src/osvr/Server/ConfigFilePaths.h.cmake_in
+++ b/src/osvr/Server/ConfigFilePaths.h.cmake_in
@@ -27,7 +27,7 @@
 
 #include <osvr/Util/PlatformConfig.h>
 namespace osvr {
-  namespace server {
+namespace server {
 
     std::vector<std::string> getDefaultConfigFilePaths() {
 
@@ -39,17 +39,19 @@ namespace osvr {
 
         std::vector<std::string> names;
         names.push_back(home + "/.osvr/osvr_server_config.json");
-        names.push_back("@CMAKE_INSTALL_FULL_SYSCONFDIR@/osvr_server_config.json");
+        names.push_back(
+            "@CMAKE_INSTALL_FULL_SYSCONFDIR@/osvr_server_config.json");
 
 #if defined(OSVR_WINDOWS)
         names.push_back(appdata + "\\OSVR\\osvr_server_config.json");
         names.push_back("osvr_server_config.json");
 #elif defined(OSVR_MACOSX)
-        names.push_back(home + "/Library/Application Support/OSVR/osvr_server_config.json");
+        names.push_back(
+            home + "/Library/Application Support/OSVR/osvr_server_config.json");
 #endif
 
         return names;
     }
-  }
+}
 }
 #endif // INCLUDED_ConfigFilePaths_h_GUID_241E9C9C_0E0E_46B0_9DED_8F8059306192

--- a/src/osvr/Server/ConfigureServerFromFile.cpp
+++ b/src/osvr/Server/ConfigureServerFromFile.cpp
@@ -1,0 +1,178 @@
+/** @file
+    @brief Header
+
+    @date 2014
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2014 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Server/Server.h>
+#include <osvr/Server/ConfigureServer.h>
+#include <osvr/Server/ConfigureServerFromFile.h>
+#include <osvr/Server/ConfigFilePaths.h>
+#include <osvr/Util/PlatformConfig.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <iostream>
+#include <fstream>
+#include <exception>
+#include <vector>
+
+namespace osvr {
+namespace server {
+
+
+    ServerPtr configureServerFromFile(std::string const &configName) {
+        using detail::out;
+        using detail::err;
+        using std::endl;
+        ServerPtr ret;
+        osvr::server::ConfigureServer srvConfig;
+
+        if(!configName.empty()) {
+            out << "Using config file '" << configName << "'" << endl;
+            std::ifstream config(configName);
+            if (!config.good()) {
+                err << "\n"
+                    << "Could not open config file!" << endl;
+                err << "Searched in the current directory; file may be "
+                       "misspelled, missing, or in a different directory." << endl;
+                return nullptr;
+            }
+            try {
+                srvConfig.loadConfig(config);
+            } catch (std::exception &e) {
+                err << "Caught exception attempting to parse server JSON config file: " << e.what() << endl;
+                return nullptr;
+            }
+        } else {
+            srvConfig.loadConfig("{}");
+        }
+        try {
+            ret = srvConfig.constructServer();
+        } catch (std::exception &e) {
+            err << "Caught exception constructing server from JSON config "
+                   "file: " << e.what() << endl;
+            return nullptr;
+        }
+
+        {
+            out << "Loading auto-loadable plugins..." << endl;
+            srvConfig.loadAutoPlugins();
+        }
+
+        {
+            out << "Loading plugins..." << endl;
+            srvConfig.loadPlugins();
+            if (!srvConfig.getSuccessfulPlugins().empty()) {
+                out << "Successful plugins:" << endl;
+                for (auto const &plugin : srvConfig.getSuccessfulPlugins()) {
+                    out << " - " << plugin << endl;
+                }
+                out << "\n";
+            }
+            if (!srvConfig.getFailedPlugins().empty()) {
+                out << "Failed plugins:" << endl;
+                for (auto const &pluginError : srvConfig.getFailedPlugins()) {
+                    out << " - " << pluginError.first << "\t"
+                        << pluginError.second << endl;
+                }
+                out << "\n";
+            }
+
+            out << "\n";
+        }
+
+        {
+            out << "Instantiating configured drivers..." << endl;
+            bool success = srvConfig.instantiateDrivers();
+            if (!srvConfig.getSuccessfulInstantiations().empty()) {
+                out << "Successes:" << endl;
+                for (auto const &driver :
+                     srvConfig.getSuccessfulInstantiations()) {
+                    out << " - " << driver << endl;
+                }
+                out << "\n";
+            }
+            if (!srvConfig.getFailedInstantiations().empty()) {
+                out << "Errors:" << endl;
+                for (auto const &error : srvConfig.getFailedInstantiations()) {
+                    out << " - " << error.first << "\t" << error.second << endl;
+                }
+                out << "\n";
+            }
+            out << "\n";
+        }
+
+        if (srvConfig.processExternalDevices()) {
+            out << "External devices found and parsed from config file."
+                << endl;
+        }
+
+        if (srvConfig.processRoutes()) {
+            out << "Routes found and parsed from config file." << endl;
+        }
+
+        if (srvConfig.processAliases()) {
+            out << "Aliases found and parsed from config file." << endl;
+        }
+
+        if (srvConfig.processDisplay()) {
+            out << "Display descriptor found and parsed from config file"
+                << endl;
+        } else {
+            out << "No valid 'display' object found in config file - server "
+                   "may use the OSVR HDK as a default." << endl;
+        }
+
+        if (srvConfig.processRenderManagerParameters()) {
+            out << "RenderManager config found and parsed from the config file"
+                << endl;
+        }
+
+        out << "Triggering a hardware detection..." << endl;
+        ret->triggerHardwareDetect();
+
+        return ret;
+    }
+
+    ServerPtr configureServerFromFirstFileInList(std::vector<std::string> const &configNames) {
+        using detail::out;
+        using detail::err;
+        using std::endl;
+        for(const auto name: configNames) {
+            std::ifstream config(name);
+            if(config.good()) {
+                return configureServerFromFile(name);
+            }
+        }
+        err << "Could not open config file!" << endl;
+        err << "Attempted the following files:" << endl;
+        for (auto i = configNames.begin(); i != configNames.end(); i++) {
+            std::cout << *i << std::endl;
+        }
+        return nullptr;
+    }
+
+} // namespace server
+} // namespace osvr

--- a/src/osvr/Server/ConfigureServerFromFile.cpp
+++ b/src/osvr/Server/ConfigureServerFromFile.cpp
@@ -41,7 +41,6 @@
 namespace osvr {
 namespace server {
 
-
     ServerPtr configureServerFromFile(std::string const &configName) {
         using detail::out;
         using detail::err;
@@ -49,20 +48,23 @@ namespace server {
         ServerPtr ret;
         osvr::server::ConfigureServer srvConfig;
 
-        if(!configName.empty()) {
+        if (!configName.empty()) {
             out << "Using config file '" << configName << "'" << endl;
             std::ifstream config(configName);
             if (!config.good()) {
                 err << "\n"
                     << "Could not open config file!" << endl;
                 err << "Searched in the current directory; file may be "
-                       "misspelled, missing, or in a different directory." << endl;
+                       "misspelled, missing, or in a different directory."
+                    << endl;
                 return nullptr;
             }
             try {
                 srvConfig.loadConfig(config);
             } catch (std::exception &e) {
-                err << "Caught exception attempting to parse server JSON config file: " << e.what() << endl;
+                err << "Caught exception attempting to parse server JSON "
+                       "config file: "
+                    << e.what() << endl;
                 return nullptr;
             }
         } else {
@@ -72,7 +74,8 @@ namespace server {
             ret = srvConfig.constructServer();
         } catch (std::exception &e) {
             err << "Caught exception constructing server from JSON config "
-                   "file: " << e.what() << endl;
+                   "file: "
+                << e.what() << endl;
             return nullptr;
         }
 
@@ -142,7 +145,8 @@ namespace server {
                 << endl;
         } else {
             out << "No valid 'display' object found in config file - server "
-                   "may use the OSVR HDK as a default." << endl;
+                   "may use the OSVR HDK as a default."
+                << endl;
         }
 
         if (srvConfig.processRenderManagerParameters()) {
@@ -156,13 +160,14 @@ namespace server {
         return ret;
     }
 
-    ServerPtr configureServerFromFirstFileInList(std::vector<std::string> const &configNames) {
+    ServerPtr configureServerFromFirstFileInList(
+        std::vector<std::string> const &configNames) {
         using detail::out;
         using detail::err;
         using std::endl;
-        for(const auto name: configNames) {
+        for (const auto name : configNames) {
             std::ifstream config(name);
-            if(config.good()) {
+            if (config.good()) {
                 return configureServerFromFile(name);
             }
         }


### PR DESCRIPTION
This enables automatic searching for config files based on a list of hardcoded paths (this can be changed if needed), or loads a default empty config if no config filename is passed.

This, together with https://github.com/OSVR/OSVR-Core/pull/264, should solve https://github.com/OSVR/OSVR-Core/issues/238, https://github.com/OSVR/OSVR-Core/issues/185, and https://github.com/OSVR/OSVR-Core/issues/171, https://github.com/OSVR/OSVR-Core/issues/172, at least, but may need some changes/tweaks.

Before we can claim full autoconfig support we also need to implement plugin directory path detection.
