### PR TITLE
Move the slash from the osvr_copy_dir arguments to its body.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -134,30 +134,30 @@ if(BUILD_SERVER_APP)
     # Copy contents of dir for both build and install trees.
     macro(osvr_copy_dir _dirname _glob _comment)
         add_custom_command(OUTPUT "${_dirname}-stamp"
-            COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:osvr_server>${_dirname}"
+            COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:osvr_server>/${_dirname}"
             COMMENT "Making ${_comment} directory"
             VERBATIM)
         set_source_files_properties("${_dirname}-stamp" PROPERTIES SYMBOLIC TRUE)
         # Grab all the files with a glob, to avoid missing one.
-        file(GLOB _files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}${_dirname}" "${CMAKE_CURRENT_SOURCE_DIR}${_dirname}/${_glob}")
+        file(GLOB _files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/${_dirname}" "${CMAKE_CURRENT_SOURCE_DIR}/${_dirname}/${_glob}")
 
         foreach(FN ${_files})
             list(APPEND FILE_OUTPUTS "${_dirname}/${FN}")
             add_custom_command(OUTPUT "${_dirname}/${FN}"
-                COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}${_dirname}/${FN}" "$<TARGET_FILE_DIR:osvr_server>${_dirname}/"
-                MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}${_dirname}/${FN}"
+                COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${_dirname}/${FN}" "$<TARGET_FILE_DIR:osvr_server>/${_dirname}/"
+                MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${_dirname}/${FN}"
                 DEPENDS "${_dirname}-stamp"
                 COMMENT "Copying ${_comment} ${FN}"
                 VERBATIM)
-            install(FILES "${CMAKE_CURRENT_SOURCE_DIR}${_dirname}/${FN}"
-                DESTINATION ${CMAKE_INSTALL_BINDIR}${_dirname} COMPONENT Server)
+            install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${_dirname}/${FN}"
+                DESTINATION ${CMAKE_INSTALL_BINDIR}/${_dirname} COMPONENT Server)
         endforeach()
     endmacro()
 
-    osvr_copy_dir(/displays *.json "JSON display descriptor")
-    osvr_copy_dir(/sample-configs *.json "sample OSVR Server config")
-    osvr_copy_dir(/external-devices *.json "OSVR Server Configs for External VRPN devices")
-    osvr_copy_dir(/external-devices/device-descriptors *.json "Device Descriptors for External VRPN devices")
+    osvr_copy_dir(displays *.json "JSON display descriptor")
+    osvr_copy_dir(sample-configs *.json "sample OSVR Server config")
+    osvr_copy_dir(external-devices *.json "OSVR Server Configs for External VRPN devices")
+    osvr_copy_dir(external-devices/device-descriptors *.json "Device Descriptors for External VRPN devices")
 
     # Have to set them as symbolic because we can't use a generator expression in add_custom_command(OUTPUT
     set_source_files_properties(${FILE_OUTPUTS} PROPERTIES SYMBOLIC TRUE)

--- a/src/osvr/Common/CMakeLists.txt
+++ b/src/osvr/Common/CMakeLists.txt
@@ -206,6 +206,10 @@ target_link_libraries(${LIBNAME_FULL}
     osvr_cxx11_flags
     ${OSVR_CODECVT_LIBRARIES})
 
+# Target-level dependency: make Util build first, because the Util build contains
+# the generated X-Macro header ReportTypesX that is included in ReportTraits.h
+add_dependencies(${LIBNAME_FULL} osvrUtil)
+
 if(OSVR_COMMON_TRACING_ETW)
     target_link_libraries(${LIBNAME_FULL} PRIVATE ETWProviders)
     add_custom_command(TARGET ${LIBNAME_FULL} POST_BUILD


### PR DESCRIPTION
Fixes permission issues on Linux where Ninja tried to make /sample-configs with obvious lack of success.

This is my attempt to resolve the same issue as #263 without adding lots of targets (and thus terrifying/petrifying Visual Studio - the header dependency tests already do a good enough job of that)

@d235j could you test and see if this solves the ninja build on Mac?  I was able to reproduce the issue building with ninja on debian jessie, and this fixed it there.

