### PR TITLE
Adding osvr_list_usbserial utility application.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -204,3 +204,11 @@ if(BUILD_SERVER_APP)
     add_custom_target(copy_osvr_server_config_files ALL
         DEPENDS ${FILE_OUTPUTS})
 endif()
+
+# Simple application to list detected USB serial devices
+add_executable(osvr_list_usbserial osvr_list_usbserial.cpp)
+target_link_libraries(osvr_list_usbserial osvrUSBSerial)
+install(TARGETS osvr_list_usbserial
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+

--- a/apps/osvr_list_usbserial.cpp
+++ b/apps/osvr_list_usbserial.cpp
@@ -1,0 +1,49 @@
+/** @file
+    @brief A sinple application that lists all detected USB serial devices.
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/USBSerial/USBSerialEnum.h>
+#include <osvr/USBSerial/USBSerialDevice.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <cstdlib>      // for EXIT_SUCCESS
+#include <iostream>     // for std::cout
+#include <ios>          // for std::hex
+#include <iomanip>      // for std::setfill, std::setw
+
+int main(int argc, char* argv[])
+{
+    for (auto dev : osvr::usbserial::Enumerator()) {
+        std::cout << std::setfill('0') << std::setw(4) << std::hex << dev->getVID()
+            << ":" << std::setfill('0') << std::setw(4) << std::hex << dev->getPID()
+            << " " << dev->getPlatformSpecificPath() << std::endl;
+    }
+
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
The `osvr_list_usbserial` application will just emit a list of detected USB serial devices. Handy for troubleshooting.