### PR TITLE
osvr_server support for cmdline options and blank config generation (resolves #228)

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -148,7 +148,7 @@ if(BUILD_SERVER_APP)
     add_executable(osvr_server
         osvr_server.cpp
         ${OSVR_SERVER_RESOURCE})
-    target_link_libraries(osvr_server osvrServer jsoncpp_lib)
+    target_link_libraries(osvr_server osvrServer boost_program_options boost_filesystem jsoncpp_lib)
     set_target_properties(osvr_server PROPERTIES
         FOLDER "OSVR Stock Applications")
     install(TARGETS osvr_server

--- a/apps/osvr_server.cpp
+++ b/apps/osvr_server.cpp
@@ -31,6 +31,7 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/optional.hpp>
 
 // Standard includes
 #include <iostream>
@@ -91,37 +92,36 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    if (!values.count(configOpt)) {
-        out << "Using default config file - pass a filename on the command "
-               "line to use a different one."
+    configName = values[configOpt].as<std::string>();
+
+    boost::optional<fs::path> configPath(configName);
+    try {
+        if (!fs::exists(*configPath)) {
+            out << "File '" << configName
+                << "' not found.  Using blank config" << endl;
+            configPath = boost::none;
+        } else {
+            if (fs::is_directory(*configPath)) {
+                err << "'" << configName << "' is a directory" << endl;
+                return -1;
+            } else if (!fs::is_regular_file(*configPath)) {
+                err << "'" << configName << "' is special file" << endl;
+                return -1;
+            }
+        }
+    } catch (fs::filesystem_error &e) {
+        err << "Could not open config file at '" << configName << "'"
             << endl;
-    } else {
-        configName = values[configOpt].as<std::string>();
+        err << "Reason " << e.what() << endl;
+        configPath = boost::none;
     }
-
-    fs::path configPath(configName);
-    if (!fs::exists(configPath)) {
-        try {
-            out << "Creating blank config at \"" << configName << "\"" << endl;
-            fs::ofstream configOut{configPath};
-            configOut << "{ }\n";
-            configOut.close();
-        } catch (fs::filesystem_error &e) {
-            err << "Could not create config file at \"" << configName << "\""
-                << endl;
-            err << "Reason " << e.what() << endl;
-        }
+    
+    if (configPath) {
+        server = osvr::server::configureServerFromFile(configName);
     } else {
-        if (fs::is_directory(configPath)) {
-            err << "\"" << configName << "\" is a directory" << endl;
-            return -1;
-        } else if (!fs::is_regular_file(configPath)) {
-            err << "\"" << configName << "\" is special file" << endl;
-            return -1;
-        }
+        server = osvr::server::configureServerFromString("{ }");
     }
-
-    server = osvr::server::configureServerFromFile(configName);
+    
     if (!server) {
         return -1;
     }

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -64,25 +64,16 @@ namespace server {
     /// @brief This is the basic common code of a server app's setup, ripped out
     /// of the main server app to make alternate server-acting apps simpler to
     /// develop.
-    inline ServerPtr configureServerFromFile(std::string const &configName) {
+    inline ServerPtr configureServerFromString(std::string const &json) {
         using detail::out;
         using detail::err;
         using std::endl;
+        
         ServerPtr ret;
-        out << "Using config file '" << configName << "'" << endl;
-        std::ifstream config(configName);
-        if (!config.good()) {
-            err << "\n"
-                << "Could not open config file!" << endl;
-            err << "Searched in the current directory; file may be "
-                   "misspelled, missing, or in a different directory." << endl;
-            return nullptr;
-        }
-
         osvr::server::ConfigureServer srvConfig;
         out << "Constructing server as configured..." << endl;
         try {
-            srvConfig.loadConfig(config);
+            srvConfig.loadConfig(json);
             ret = srvConfig.constructServer();
         } catch (std::exception &e) {
             err << "Caught exception constructing server from JSON config "
@@ -168,6 +159,26 @@ namespace server {
         ret->triggerHardwareDetect();
 
         return ret;
+    }
+
+    /// @Brief Convenience wrapper for configureServerFromString
+    inline ServerPtr configureServerFromFile(std::string const &configName) {
+        using detail::out;
+        using detail::err;
+        using std::endl;
+        
+        out << "Using config file '" << configName << "'" << endl;
+        std::ifstream config(configName);
+        if (!config.good()) {
+            err << "\n"
+                << "Could not open config file!" << endl;
+            err << "Searched in the current directory; file may be "
+                   "misspelled, missing, or in a different directory." << endl;
+            return nullptr;
+        }
+
+        std::string json(std::istreambuf_iterator<char>(config), {});
+        return configureServerFromString(json);
     }
 } // namespace server
 } // namespace osvr


### PR DESCRIPTION
Patch to resolve #228.  Includes options --config= and --help.  Will create config with contents "{ }" in the event that the given config doesn't exist
