### PR TITLE
directx_samplegrabber_callback: Add missing DirectShow include.

### DIFF
--- a/plugins/videobasedtracker/DirectShowCameraLib/directx_samplegrabber_callback.h
+++ b/plugins/videobasedtracker/DirectShowCameraLib/directx_samplegrabber_callback.h
@@ -32,6 +32,7 @@
 // - none
 
 // Standard includes
+#include <dshow.h>
 #include "qedit_wrapper.h"
 
 // This class is used to handle callbacks from the SampleGrabber filter.  It


### PR DESCRIPTION
Without this include I am not able to compile this module, it results in a ton of undefined identifier errors.