### PR TITLE
Kalman improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,12 @@ if(BUILD_WITH_OPENCV)
     if(NOT OpenCV_FOUND)
         message(FATAL_ERROR "BUILD_WITH_OPENCV is enabled, but OpenCV was not found! Either help CMake find OpenCV or disable BUILD_WITH_OPENCV.")
     endif()
+    if(OpenCV_VERSION VERSION_LESS 2.4)
+        # At least one 2.3 version (used in Precise) is missing a header that
+        # breaks their Eigen compatibility header. This seemed like the easiest
+        # fix.
+        set(BUILD_OPENCV_CAMERA_PLUGIN OFF)
+    endif()
     if(WIN32)
         set(OSVR_COPY_OPENCV ON)
     endif()

--- a/inc/osvr/Kalman/AbsoluteOrientationMeasurement.h
+++ b/inc/osvr/Kalman/AbsoluteOrientationMeasurement.h
@@ -91,7 +91,8 @@ namespace kalman {
         /// the measurement from the predicted state, and returns the
         /// difference.
         ///
-        /// State type doesn't matter as long as we can getCombinedQuaternion()
+        /// State type doesn't matter as long as we can
+        /// `.getCombinedQuaternion()`
         template <typename State>
         MeasurementVector getResidual(State const &s) const {
             const Eigen::Quaterniond prediction = s.getCombinedQuaternion();
@@ -102,6 +103,13 @@ namespace kalman {
         /// Convenience method to be able to store and re-use measurements.
         void setMeasurement(Eigen::Quaterniond const &quat) {
             m_measurement = quat;
+        }
+
+        /// Get the block of jacobian that is non-zero: your subclass will have
+        /// to put it where it belongs for each particular state type.
+        types::Matrix<DIMENSION, 3>
+            getJacobianWRTIncRot(types::Vector<3> const &incRot) const {
+            return external_quat::jacobian(incRot);
         }
 
       private:
@@ -134,7 +142,7 @@ namespace kalman {
             using namespace pose_externalized_rotation;
             using Jacobian = types::Matrix<DIMENSION, STATE_DIMENSION>;
             Jacobian ret = Jacobian::Zero();
-            ret.block<DIMENSION, 3>(0, 3) = external_quat::jacobian(
+            ret.block<DIMENSION, 3>(0, 3) = Base::getJacobianWRTIncRot(
                 incrementalOrientation(s.stateVector()));
             return ret;
         }

--- a/inc/osvr/Kalman/AbsolutePositionMeasurement.h
+++ b/inc/osvr/Kalman/AbsolutePositionMeasurement.h
@@ -62,10 +62,10 @@ namespace kalman {
         /// the measurement from the predicted state, and returns the
         /// difference.
         ///
-        /// State type doesn't matter as long as we can getPosition()
+        /// State type doesn't matter as long as we can `.position()`
         template <typename State>
         MeasurementVector getResidual(State const &s) const {
-            MeasurementVector residual = m_pos - s.getPosition();
+            MeasurementVector residual = m_pos - s.position();
             return residual;
         }
 

--- a/inc/osvr/Kalman/AngularVelocityMeasurement.h
+++ b/inc/osvr/Kalman/AngularVelocityMeasurement.h
@@ -59,11 +59,11 @@ namespace kalman {
         /// the measurement from the predicted state, and returns the
         /// difference.
         ///
-        /// State type doesn't matter as long as we can getAngularVelocity()
+        /// State type doesn't matter as long as we can `.angularVelocity()`
         template <typename State>
         MeasurementVector getResidual(State const &s) const {
             const MeasurementVector residual =
-                m_measurement - s.getAngularVelocity();
+                m_measurement - s.angularVelocity();
             return residual;
         }
 

--- a/inc/osvr/Kalman/OrientationState.h
+++ b/inc/osvr/Kalman/OrientationState.h
@@ -132,7 +132,7 @@ namespace kalman {
 
             /// Intended for startup use.
             void setQuaternion(Eigen::Quaterniond const &quaternion) {
-                m_orientation = quaternion;
+                m_orientation = quaternion.normalized();
             }
 
             void postCorrect() { externalizeRotation(); }
@@ -158,7 +158,8 @@ namespace kalman {
 
             Eigen::Quaterniond getCombinedQuaternion() const {
                 /// @todo is just quat multiplication OK here? Order right?
-                return incrementalOrientationToQuat(m_state) * m_orientation;
+                return (incrementalOrientationToQuat(m_state) * m_orientation)
+                    .normalized();
             }
 
           private:

--- a/inc/osvr/Kalman/OrientationState.h
+++ b/inc/osvr/Kalman/OrientationState.h
@@ -41,8 +41,7 @@ namespace kalman {
     namespace orient_externalized_rotation {
         using Dimension = types::DimensionConstant<6>;
         using StateVector = types::DimVector<Dimension>;
-        using StateVectorBlock3 =
-            StateVector::FixedSegmentReturnType<3>::Type;
+        using StateVectorBlock3 = StateVector::FixedSegmentReturnType<3>::Type;
         using ConstStateVectorBlock3 =
             StateVector::ConstFixedSegmentReturnType<3>::Type;
 
@@ -144,12 +143,12 @@ namespace kalman {
 
             void normalizeQuaternion() { m_orientation.normalize(); }
 
-            StateVectorBlock3 getAngularVelocity() {
-                return angularVelocity(m_state);
+            StateVectorBlock3 angularVelocity() {
+                return orient_externalized_rotation::angularVelocity(m_state);
             }
 
-            ConstStateVectorBlock3 getAngularVelocity() const {
-                return angularVelocity(m_state);
+            ConstStateVectorBlock3 angularVelocity() const {
+                return orient_externalized_rotation::angularVelocity(m_state);
             }
 
             Eigen::Quaterniond const &getQuaternion() const {

--- a/inc/osvr/Kalman/PoseSeparatelyDampedConstantVelocity.h
+++ b/inc/osvr/Kalman/PoseSeparatelyDampedConstantVelocity.h
@@ -1,0 +1,119 @@
+/** @file
+    @brief Header
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_PoseSeparatelyDampedConstantVelocity_h_GUID_4BB00A8D_B12F_47BF_EA91_599233CED644
+#define INCLUDED_PoseSeparatelyDampedConstantVelocity_h_GUID_4BB00A8D_B12F_47BF_EA91_599233CED644
+
+// Internal Includes
+#include "PoseState.h"
+#include "PoseConstantVelocity.h"
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <cassert>
+
+namespace osvr {
+namespace kalman {
+    /// A basically-constant-velocity model, with the addition of some
+    /// damping of the velocities inspired by TAG. This model has separate
+    /// damping/attenuation of linear and angular velocities.
+    class PoseSeparatelyDampedConstantVelocityProcessModel {
+      public:
+        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        using State = pose_externalized_rotation::State;
+        using StateVector = pose_externalized_rotation::StateVector;
+        using StateSquareMatrix = pose_externalized_rotation::StateSquareMatrix;
+        using BaseProcess = PoseConstantVelocityProcessModel;
+        using NoiseAutocorrelation = BaseProcess::NoiseAutocorrelation;
+        PoseSeparatelyDampedConstantVelocityProcessModel(
+            double positionDamping = 0.3, double orientationDamping = 0.01,
+            double positionNoise = 0.01, double orientationNoise = 0.1)
+            : m_constantVelModel(positionNoise, orientationNoise) {
+            setDamping(positionDamping, orientationDamping);
+        }
+
+        void setNoiseAutocorrelation(double positionNoise = 0.01,
+                                     double orientationNoise = 0.1) {
+            m_constantVelModel.setNoiseAutocorrelation(positionNoise,
+                                                       orientationNoise);
+        }
+
+        void setNoiseAutocorrelation(NoiseAutocorrelation const &noise) {
+            m_constantVelModel.setNoiseAutocorrelation(noise);
+        }
+        /// Set the damping - must be in (0, 1)
+        void setDamping(double posDamping, double oriDamping) {
+            if (posDamping > 0 && posDamping < 1) {
+                m_posDamp = posDamping;
+            }
+            if (oriDamping > 0 && oriDamping < 1) {
+                m_oriDamp = oriDamping;
+            }
+        }
+
+        /// Also known as the "process model jacobian" in TAG, this is A.
+        StateSquareMatrix getStateTransitionMatrix(State const &,
+                                                   double dt) const {
+            return pose_externalized_rotation::
+                stateTransitionMatrixWithSeparateVelocityDamping(dt, m_posDamp,
+                                                                 m_oriDamp);
+        }
+
+        void predictState(State &s, double dt) {
+            auto xHatMinus = computeEstimate(s, dt);
+            auto Pminus = predictErrorCovariance(s, *this, dt);
+            s.setStateVector(xHatMinus);
+            s.setErrorCovariance(Pminus);
+        }
+
+        /// This is Q(deltaT) - the Sampled Process Noise Covariance
+        /// @return a matrix of dimension n x n. Note that it is real
+        /// symmetrical (self-adjoint), so .selfAdjointView<Eigen::Upper>()
+        /// might provide useful performance enhancements.
+        StateSquareMatrix getSampledProcessNoiseCovariance(double dt) const {
+            return m_constantVelModel.getSampledProcessNoiseCovariance(dt);
+        }
+
+        /// Returns a 12-element vector containing a predicted state based on a
+        /// constant velocity process model.
+        StateVector computeEstimate(State &state, double dt) const {
+            StateVector ret = m_constantVelModel.computeEstimate(state, dt);
+            // Dampen velocities
+            pose_externalized_rotation::separatelyDampenVelocities(
+                ret, m_posDamp, m_oriDamp, dt);
+            return ret;
+        }
+
+      private:
+        BaseProcess m_constantVelModel;
+        double m_posDamp = 0.2;
+        double m_oriDamp = 0.01;
+    };
+
+} // namespace kalman
+} // namespace osvr
+
+#endif // INCLUDED_PoseSeparatelyDampedConstantVelocity_h_GUID_4BB00A8D_B12F_47BF_EA91_599233CED644

--- a/inc/osvr/Kalman/PoseState.h
+++ b/inc/osvr/Kalman/PoseState.h
@@ -197,24 +197,28 @@ namespace kalman {
                 incrementalOrientation(m_state) = Eigen::Vector3d::Zero();
             }
 
-            StateVectorBlock3 getPosition() { return position(m_state); }
-
-            ConstStateVectorBlock3 getPosition() const {
-                return position(m_state);
+            StateVectorBlock3 position() {
+                return pose_externalized_rotation::position(m_state);
             }
 
-            StateVectorBlock3 getVelocity() { return velocity(m_state); }
-
-            ConstStateVectorBlock3 getVelocity() const {
-                return velocity(m_state);
+            ConstStateVectorBlock3 position() const {
+                return pose_externalized_rotation::position(m_state);
             }
 
-            StateVectorBlock3 getAngularVelocity() {
-                return angularVelocity(m_state);
+            StateVectorBlock3 velocity() {
+                return pose_externalized_rotation::velocity(m_state);
             }
 
-            ConstStateVectorBlock3 getAngularVelocity() const {
-                return angularVelocity(m_state);
+            ConstStateVectorBlock3 velocity() const {
+                return pose_externalized_rotation::velocity(m_state);
+            }
+
+            StateVectorBlock3 angularVelocity() {
+                return pose_externalized_rotation::angularVelocity(m_state);
+            }
+
+            ConstStateVectorBlock3 angularVelocity() const {
+                return pose_externalized_rotation::angularVelocity(m_state);
             }
 
             Eigen::Quaterniond const &getQuaternion() const {

--- a/inc/osvr/Kalman/PoseState.h
+++ b/inc/osvr/Kalman/PoseState.h
@@ -160,7 +160,7 @@ namespace kalman {
 
             /// Intended for startup use.
             void setQuaternion(Eigen::Quaterniond const &quaternion) {
-                m_orientation = quaternion;
+                m_orientation = quaternion.normalized();
             }
 
             void postCorrect() { externalizeRotation(); }

--- a/inc/osvr/Kalman/PoseState.h
+++ b/inc/osvr/Kalman/PoseState.h
@@ -41,13 +41,11 @@ namespace kalman {
     namespace pose_externalized_rotation {
         using Dimension = types::DimensionConstant<12>;
         using StateVector = types::DimVector<Dimension>;
-        using StateVectorBlock3 =
-            StateVector::FixedSegmentReturnType<3>::Type;
+        using StateVectorBlock3 = StateVector::FixedSegmentReturnType<3>::Type;
         using ConstStateVectorBlock3 =
             StateVector::ConstFixedSegmentReturnType<3>::Type;
 
-        using StateVectorBlock6 =
-            StateVector::FixedSegmentReturnType<6>::Type;
+        using StateVectorBlock6 = StateVector::FixedSegmentReturnType<6>::Type;
         using StateSquareMatrix = types::DimSquareMatrix<Dimension>;
 
         /// @name Accessors to blocks in the state vector.
@@ -97,19 +95,39 @@ namespace kalman {
 
             return A;
         }
+        /// Function used to compute the coefficient m in v_new = m * v_old.
+        /// The damping value is for exponential decay.
         inline double computeAttenuation(double damping, double dt) {
             return std::pow(damping, dt);
         }
+
+        /// Returns the state transition matrix for a constant velocity with a
+        /// single damping parameter (not for direct use in computing state
+        /// transition, because it is very sparse, but in computing other
+        /// values)
         inline StateSquareMatrix
         stateTransitionMatrixWithVelocityDamping(double dt, double damping) {
-
             // eq. 4.5 in Welch 1996
-
             auto A = stateTransitionMatrix(dt);
-            auto attenuation = computeAttenuation(damping, dt);
-            A.bottomRightCorner<6, 6>() *= attenuation;
+            A.bottomRightCorner<6, 6>() *= computeAttenuation(damping, dt);
             return A;
         }
+
+        /// Returns the state transition matrix for a constant velocity with
+        /// separate damping paramters for linear and angular velocity (not for
+        /// direct use in computing state transition, because it is very sparse,
+        /// but in computing other values)
+        inline StateSquareMatrix
+        stateTransitionMatrixWithSeparateVelocityDamping(double dt,
+                                                         double posDamping,
+                                                         double oriDamping) {
+            // eq. 4.5 in Welch 1996
+            auto A = stateTransitionMatrix(dt);
+            A.block<3, 3>(6, 6) *= computeAttenuation(posDamping, dt);
+            A.bottomRightCorner<3, 3>() *= computeAttenuation(oriDamping, dt);
+            return A;
+        }
+
         /// Computes A(deltaT)xhat(t-deltaT)
         inline StateVector applyVelocity(StateVector const &state, double dt) {
             // eq. 4.5 in Welch 1996
@@ -123,10 +141,19 @@ namespace kalman {
             return ret;
         }
 
+        /// Dampen all 6 components of velocity by a single factor.
         inline void dampenVelocities(StateVector &state, double damping,
                                      double dt) {
             auto attenuation = computeAttenuation(damping, dt);
             velocities(state) *= attenuation;
+        }
+
+        /// Separately dampen the linear and angular velocities
+        inline void separatelyDampenVelocities(StateVector &state,
+                                               double posDamping,
+                                               double oriDamping, double dt) {
+            velocity(state) *= computeAttenuation(posDamping, dt);
+            angularVelocity(state) *= computeAttenuation(oriDamping, dt);
         }
 
         inline Eigen::Quaterniond

--- a/inc/osvr/Kalman/PoseStateExponentialMap.h
+++ b/inc/osvr/Kalman/PoseStateExponentialMap.h
@@ -3,6 +3,8 @@
    formalism" instead of the "internal incremental rotation, externalized
    quaternion" representation.
 
+   @todo incomplete
+
     @date 2015
 
     @author

--- a/inc/osvr/Kalman/PoseStateExponentialMap.h
+++ b/inc/osvr/Kalman/PoseStateExponentialMap.h
@@ -156,10 +156,12 @@ namespace kalman {
                 m_cacheData.reset(Eigen::Vector3d(orientation(m_state)));
             }
 
-            StateVectorBlock3 getPosition() { return position(m_state); }
+            StateVectorBlock3 position() {
+                return pose_exp_map::position(m_state);
+            }
 
-            ConstStateVectorBlock3 getPosition() const {
-                return position(m_state);
+            ConstStateVectorBlock3 position() const {
+                return pose_exp_map::position(m_state);
             }
 
             Eigen::Quaterniond const &getQuaternion() {
@@ -169,18 +171,20 @@ namespace kalman {
                 return m_cacheData.getRotationMatrix();
             }
 
-            StateVectorBlock3 getVelocity() { return velocity(m_state); }
-
-            ConstStateVectorBlock3 getVelocity() const {
-                return velocity(m_state);
+            StateVectorBlock3 velocity() {
+                return pose_exp_map::velocity(m_state);
             }
 
-            StateVectorBlock3 getAngularVelocity() {
-                return angularVelocity(m_state);
+            ConstStateVectorBlock3 velocity() const {
+                return pose_exp_map::velocity(m_state);
             }
 
-            ConstStateVectorBlock3 getAngularVelocity() const {
-                return angularVelocity(m_state);
+            StateVectorBlock3 angularVelocity() {
+                return pose_exp_map::angularVelocity(m_state);
+            }
+
+            ConstStateVectorBlock3 angularVelocity() const {
+                return pose_exp_map::angularVelocity(m_state);
             }
 
           private:

--- a/plugins/videobasedtracker/BeaconBasedPoseEstimator.cpp
+++ b/plugins/videobasedtracker/BeaconBasedPoseEstimator.cpp
@@ -448,7 +448,7 @@ namespace vbtracker {
         m_state.setQuaternion(quat);
         m_state.setErrorCovariance(StateVec(InitialStateError).asDiagonal());
 
-        m_model.setDamping(0.3);
+        m_model.setDamping(0.3, 0.01);
         m_model.setNoiseAutocorrelation(
             kalman::types::Vector<6>(NoiseAutoCorrelation));
 

--- a/plugins/videobasedtracker/BeaconBasedPoseEstimator.cpp
+++ b/plugins/videobasedtracker/BeaconBasedPoseEstimator.cpp
@@ -239,16 +239,16 @@ namespace vbtracker {
         OSVR_PoseState ret;
         util::eigen_interop::map(ret).rotation() = m_state.getQuaternion();
         util::eigen_interop::map(ret).translation() =
-            m_convertInternalPositionRepToExternal(m_state.getPosition());
+            m_convertInternalPositionRepToExternal(m_state.position());
         return ret;
     }
 
     Eigen::Vector3d BeaconBasedPoseEstimator::GetLinearVelocity() const {
-        return m_state.getVelocity() / LINEAR_SCALE_FACTOR;
+        return m_state.velocity() / LINEAR_SCALE_FACTOR;
     }
 
     Eigen::Vector3d BeaconBasedPoseEstimator::GetAngularVelocity() const {
-        return m_state.getAngularVelocity();
+        return m_state.angularVelocity();
     }
 
     bool
@@ -444,9 +444,7 @@ namespace vbtracker {
         // Note that here, units are millimeters and radians, and x and z are
         // the lateral translation dimensions, with z being distance from camera
         using StateVec = kalman::types::DimVector<State>;
-        StateVec state(StateVec::Zero());
-        state.head<3>() = xlate;
-        m_state.setStateVector(state);
+        m_state.position() = xlate;
         m_state.setQuaternion(quat);
         m_state.setErrorCovariance(StateVec(InitialStateError).asDiagonal());
 

--- a/plugins/videobasedtracker/BeaconBasedPoseEstimator.cpp
+++ b/plugins/videobasedtracker/BeaconBasedPoseEstimator.cpp
@@ -273,6 +273,9 @@ namespace vbtracker {
         if (m_framesInProbation > MAX_PROBATION_FRAMES) {
             // Kalman filter started returning too high of residuals - going
             // back to RANSAC until we get a good lock again.
+            std::cout << "Video-based tracker: lost fix, beacon tracking "
+                         "returning to startup state"
+                      << std::endl;
             m_gotPose = false;
             m_framesInProbation = 0;
         }
@@ -451,8 +454,8 @@ namespace vbtracker {
         m_model.setNoiseAutocorrelation(
             kalman::types::Vector<6>(NoiseAutoCorrelation));
 
-        std::cout << "State:" << m_state.stateVector().transpose()
-                  << "\n  with quaternion "
+        std::cout << "Video-based tracker: Beacon entering run state: pos:"
+                  << m_state.position().transpose() << "\n orientation: "
                   << m_state.getQuaternion().coeffs().transpose() << std::endl;
     }
 

--- a/plugins/videobasedtracker/BeaconBasedPoseEstimator.h
+++ b/plugins/videobasedtracker/BeaconBasedPoseEstimator.h
@@ -34,7 +34,7 @@
 #include <osvr/Util/ClientReportTypesC.h>
 #include <osvr/Kalman/PureVectorState.h>
 #include <osvr/Kalman/PoseState.h>
-#include <osvr/Kalman/PoseDampedConstantVelocity.h>
+#include <osvr/Kalman/PoseSeparatelyDampedConstantVelocity.h>
 
 // Standard includes
 #include <vector>
@@ -173,7 +173,7 @@ namespace vbtracker {
         cv::Mat m_tvec;
         using State = kalman::pose_externalized_rotation::State;
         State m_state;
-        using ProcessModel = osvr::kalman::PoseDampedConstantVelocityProcessModel;
+        using ProcessModel = osvr::kalman::PoseSeparatelyDampedConstantVelocityProcessModel;
         ProcessModel m_model;
         /// @}
 

--- a/plugins/videobasedtracker/BeaconBasedPoseEstimator_Kalman.cpp
+++ b/plugins/videobasedtracker/BeaconBasedPoseEstimator_Kalman.cpp
@@ -155,13 +155,10 @@ namespace vbtracker {
             incrementProbation = numBad * 2 > numGood;
             if (!incrementProbation) {
                 // OK, we're good again
-                std::cout << "Re-attained our tracking goal." << std::endl;
                 m_framesInProbation = 0;
             }
         }
         if (incrementProbation) {
-            std::cout << "Fell below our target for tracking residuals: "
-                      << numBad << " bad, " << numGood << " good." << std::endl;
             m_framesInProbation++;
         }
         /// Output to the OpenCV state types so we can see the reprojection

--- a/plugins/videobasedtracker/BeaconBasedPoseEstimator_Kalman.cpp
+++ b/plugins/videobasedtracker/BeaconBasedPoseEstimator_Kalman.cpp
@@ -164,7 +164,7 @@ namespace vbtracker {
         /// Output to the OpenCV state types so we can see the reprojection
         /// debug view.
         m_rvec = eiQuatToRotVec(m_state.getQuaternion());
-        cv::eigen2cv(m_state.getPosition().eval(), m_tvec);
+        cv::eigen2cv(m_state.position().eval(), m_tvec);
         return true;
     }
 
@@ -177,7 +177,7 @@ namespace vbtracker {
         OSVR_PoseState ret;
         util::eigen_interop::map(ret).rotation() = state.getQuaternion();
         util::eigen_interop::map(ret).translation() =
-            m_convertInternalPositionRepToExternal(state.getPosition());
+            m_convertInternalPositionRepToExternal(state.position());
         return ret;
     }
 

--- a/plugins/videobasedtracker/ImagePointMeasurement.h
+++ b/plugins/videobasedtracker/ImagePointMeasurement.h
@@ -73,15 +73,14 @@ namespace vbtracker {
                 kalman::pose_externalized_rotation::incrementalOrientation(
                     state.a().stateVector());
             m_rotatedObjPoint = m_rot * m_beacon;
-            m_rotatedTranslatedPoint =
-                m_rotatedObjPoint + state.a().getPosition();
-            m_xlate = state.a().getPosition();
+            m_rotatedTranslatedPoint = m_rotatedObjPoint + state.a().position();
+            m_xlate = state.a().position();
         }
         Vector getResidual(State const &state) const {
             // 3d position of beacon
             Eigen::Vector3d beacon = state.b().stateVector();
             Eigen::Vector2d predicted = projectPoint(
-                state.a().getPosition(), state.a().getCombinedQuaternion(),
+                state.a().position(), state.a().getCombinedQuaternion(),
                 m_cam.focalLength, m_cam.principalPoint,
                 state.b().stateVector());
             return m_measurement - predicted;

--- a/plugins/videoimufusion/RunningData.h
+++ b/plugins/videoimufusion/RunningData.h
@@ -94,11 +94,12 @@ class VideoIMUFusion::RunningData {
     Eigen::Quaterniond getOrientation() const {
         return state().getQuaternion();
     }
-    Eigen::Vector3d getPosition() const { return state().getPosition(); }
+    Eigen::Vector3d getPosition() const { return state().position(); }
 
     Eigen::Isometry3d takeCameraPoseToRoom(OSVR_PoseState const &pose) {
-        return m_cTr.linear() * (Eigen::Translation3d(m_cTr.translation()) *
-               osvr::util::eigen_interop::map(pose).transform());
+        return m_cTr.linear() *
+               (Eigen::Translation3d(m_cTr.translation()) *
+                osvr::util::eigen_interop::map(pose).transform());
     }
 
     Eigen::Matrix<double, 12, 12> const &getErrorCovariance() const {

--- a/plugins/videoimufusion/RunningDataPredictCorrect.cpp
+++ b/plugins/videoimufusion/RunningDataPredictCorrect.cpp
@@ -47,18 +47,12 @@ void VideoIMUFusion::RunningData::handleIMUReport(
 
 void VideoIMUFusion::RunningData::handleIMUVelocity(
     const OSVR_TimeValue &timestamp, const Eigen::Vector3d &angVel) {
-    Eigen::Matrix<double, 12, 1> x = state().stateVector();
-    osvr::kalman::pose_externalized_rotation::angularVelocity(x) = angVel;
-    state().setStateVector(x);
+    state().angularVelocity() = angVel;
 }
 
 void VideoIMUFusion::RunningData::handleVideoTrackerReport(
     const OSVR_TimeValue &timestamp, const OSVR_PoseReport &report) {
-    Eigen::Isometry3d roomPose = takeCameraPoseToRoom(report.pose);
-    Eigen::Matrix<double, 12, 1> x = state().stateVector();
-    osvr::kalman::pose_externalized_rotation::position(x) =
-        roomPose.translation();
-    state().setStateVector(x);
+    state().position() = takeCameraPoseToRoom(report.pose).translation();
 }
 
 /// Returns true if we succeeded and can filter in some data.


### PR DESCRIPTION
These are some small improvements to the Kalman stuff mainly - a bit of output cleanup in the video tracker and a process model switch (separately damping the linear and angular velocity).

Note that they do contain a breaking API change for the pose and orientation states - the various `get` methods that directly accessed a block of the state vector (so, all but `getQuaternion()`) have lost their `get` prefix, since it was causing me to forget that they could be assigned to, so I was doing backflips to extract the whole state vector, modify the part I wanted, then set the whole state vector.  I think I originally put the "get" prefix on there to avoid ambiguity in compilation, but that was relatively easy to fix by qualifying with namespaces. Now, it's just a little bit dissimilar WRT the quaternion, but frankly the external quaternion isn't part of the state vector and hiding that isn't probably within the responsibility of the kalman framework, since if you don't know/understand that you'll probably have a hard time using a filter overal.