### PR TITLE
Resolved conflicts in stdInt while compiling in Visual Studio 2010

### DIFF
--- a/inc/osvr/Util/StdInt.h
+++ b/inc/osvr/Util/StdInt.h
@@ -31,7 +31,7 @@
 
 /* IWYU pragma: begin_exports */
 
-#if !defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER > 1600)
+#if !defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER >= 1600)
 #include <stdint.h>
 #else
 #include "MSStdIntC.h"


### PR DESCRIPTION
stdint.h is available starting with Visual Studio 2010, so we must include it
because others headers will include it and cause conflicts
(at least redefenition error of int_fast16_t and uint_fast16_t)