### PR TITLE
Fix build race

### DIFF
--- a/src/osvr/Common/CMakeLists.txt
+++ b/src/osvr/Common/CMakeLists.txt
@@ -207,10 +207,6 @@ target_link_libraries(${LIBNAME_FULL}
     osvr_cxx11_flags
     ${OSVR_CODECVT_LIBRARIES})
 
-# Target-level dependency: make Util build first, because the Util build contains
-# the generated X-Macro header ReportTypesX that is included in ReportTraits.h
-add_dependencies(${LIBNAME_FULL} osvrUtil)
-
 if(OSVR_COMMON_TRACING_ETW)
     target_link_libraries(${LIBNAME_FULL} PRIVATE ETWProviders)
     add_custom_command(TARGET ${LIBNAME_FULL} POST_BUILD

--- a/src/osvr/GenerateXMacro.cmake
+++ b/src/osvr/GenerateXMacro.cmake
@@ -35,3 +35,28 @@ function(osvr_generate_x_macro)
         VERBATIM
         COMMENT "Generating X-Macro file ${XMACRO_OUTPUT}")
 endfunction()
+
+include(GenerateXMacroFunction.cmake)
+
+# Generate an x-macro header at cmake/configure time.
+# Args:
+#  OUTPUT complete_path_to_outfilename (required)
+#  INVOCATION_NAME invocation_macro_name (required)
+#  ELEMENTS the elements of the list to generate the X macro for.
+function(osvr_generate_x_macro_now)
+    set(__func__ osvr_generate_x_macro_now)
+    cmake_parse_arguments(XMACRO "" "OUTPUT;INVOCATION_NAME" "ELEMENTS" ${ARGN})
+    foreach(required OUTPUT INVOCATION_NAME ELEMENTS)
+        if(NOT XMACRO_${required})
+            message(FATAL_ERROR "${__func__} requires the ${required} argument to be passed!")
+        endif()
+    endforeach()
+    if(NOT IS_ABSOLUTE "${XMACRO_OUTPUT}")
+        message(FATAL_ERROR "${__func__} requires the OUTPUT argument to be an absolute path!")
+    endif()
+    message(STATUS "Generating ${XMACRO_OUTPUT}")
+    __osvr_generate_xmacro_contents_now("${OSVR_X_MACRO_TEMPLATE}"
+        "${XMACRO_OUTPUT}"
+        "${XMACRO_INVOCATION_NAME}"
+        ${XMACRO_ELEMENTS})
+endfunction()

--- a/src/osvr/GenerateXMacroFunction.cmake
+++ b/src/osvr/GenerateXMacroFunction.cmake
@@ -1,0 +1,9 @@
+# Shared implementation between build-time and config-time x-macro generation.
+function(__osvr_generate_xmacro_contents_now INFILE OUTFILE INVOKE)
+    set(OSVR_XMACRO_CONTENTS)
+    foreach(elt ${ARGN})
+        set(OSVR_XMACRO_CONTENTS "${OSVR_XMACRO_CONTENTS} \\\nOSVR_X(${elt})")
+    endforeach()
+    set(OSVR_XMACRO_INVOKE ${INVOKE})
+    configure_file("${INFILE}" "${OUTFILE}" @ONLY NEWLINE_STYLE LF)
+endfunction()

--- a/src/osvr/GenerateXMacroScript.cmake
+++ b/src/osvr/GenerateXMacroScript.cmake
@@ -1,5 +1,2 @@
-set(OSVR_XMACRO_CONTENTS)
-foreach(elt ${ELEMENTS})
-    set(OSVR_XMACRO_CONTENTS "${OSVR_XMACRO_CONTENTS} \\\nOSVR_X(${elt})")
-endforeach()
-configure_file("${INFILE}" "${OUTFILE}" @ONLY NEWLINE_STYLE LF)
+include("${CMAKE_CURRENT_LIST_DIR}/GenerateXMacroFunction.cmake")
+__osvr_generate_xmacro_contents_now("${INFILE}" "${OUTFILE}" ${OSVR_XMACRO_INVOKE} ${ELEMENTS})

--- a/src/osvr/Util/CMakeLists.txt
+++ b/src/osvr/Util/CMakeLists.txt
@@ -29,7 +29,7 @@ configure_file(StdAlignWrapper.h.in "${CMAKE_CURRENT_BINARY_DIR}/StdAlignWrapper
 ###
 osvr_setup_lib_vars(Util)
 
-osvr_generate_x_macro(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ReportTypesX.h"
+osvr_generate_x_macro_now(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ReportTypesX.h"
     INVOCATION_NAME OSVR_INVOKE_REPORT_TYPES_XMACRO
     ELEMENTS
     ${OSVR_REPORT_TYPES})

--- a/vendor/comutils/ComVariant.h
+++ b/vendor/comutils/ComVariant.h
@@ -274,6 +274,19 @@ template <> struct VariantTypeTraits<const char *> {
         return v && contains<Dest>(v.get());
     }
 
+    /// @brief Determines if the type of data in the variant can be described as
+    /// an array of the type parameter @p Dest (without coercion)
+    template <typename Dest, typename T>
+    inline detail::enable_for_variants_t<T, bool> containsArray(T const &v) {
+        return (v.vt == detail::VariantTypeTraits<Dest>::vt & VT_ARRAY);
+    }
+    /// @overload
+    /// For wrapped variants.
+    template <typename Dest, typename T>
+    inline bool containsArray(VariantWrapper<T> const &v) {
+        return v && containsArray<Dest>(v.get());
+    }
+
     /// @brief Determines if the variant passed is "empty"
     template <typename T>
     inline detail::enable_for_variants_t<T, bool> is_empty(T const &v) {

--- a/vendor/comutils/ComVariant.h
+++ b/vendor/comutils/ComVariant.h
@@ -51,9 +51,7 @@ namespace variant {
                                        std::is_same<T, VARIANTARG>::value>;
 
         /// @brief An enable_if_t-alike that has the specific condition built in
-        /// as
-        /// well
-        /// as a default result type.
+        /// as well as a default result type.
         template <typename T, typename Result = void *>
         using enable_for_variants_t =
             typename std::enable_if<is_variant_type<T>::value, Result>::type;
@@ -187,8 +185,7 @@ template <> struct VariantTypeTraits<const char *> {
         }
 
         /// @brief Copy-assignment - copies a variant (without following
-        /// indirection
-        /// of VT_BYREF)
+        /// indirection of VT_BYREF)
         type &operator=(VariantWrapper const &other) {
             if (!other) {
                 throw std::logic_error(
@@ -265,8 +262,7 @@ template <> struct VariantTypeTraits<const char *> {
     using VariantArg = VariantWrapper<VARIANTARG>;
 
     /// @brief Determines if the type of data in the variant can be described as
-    /// the
-    /// type parameter @p Dest (without coercion)
+    /// the type parameter @p Dest (without coercion)
     template <typename Dest, typename T>
     inline detail::enable_for_variants_t<T, bool> contains(T const &v) {
         return (v.vt == detail::VariantTypeTraits<Dest>::vt);
@@ -291,8 +287,7 @@ template <> struct VariantTypeTraits<const char *> {
     }
 
     /// @brief Get the data of type @p Dest from the variant: no
-    /// conversion/coercion
-    /// applied.
+    /// conversion/coercion applied.
     template <typename Dest, typename T>
     inline detail::enable_for_variants_t<T, Dest> get(T const &v) {
         if (!contains<Dest>(v)) {


### PR DESCRIPTION
This will fix the intermittent failures related to the ReportTypesX header. We're now generating that, if required, at cmake time, rather than during the build, because I can't see how to make the dependencies work out right without making it a target of its own, which seems like overkill.