### PR TITLE
Reverted commit ec26287b0ed364dba1a442e3cccaacb76becafa8

### DIFF
--- a/inc/osvr/Common/InterfaceState.h
+++ b/inc/osvr/Common/InterfaceState.h
@@ -68,14 +68,6 @@ namespace common {
         template <typename ReportType>
         void setStateFromReport(util::time::TimeValue const &timestamp,
                                 ReportType const &report) {
-            if (hasState<ReportType>()) {
-                auto &oldTimestamp =
-                    typepack::cget<ReportType, StateMap>(m_states)->timestamp;
-                if (osvrTimeValueGreater(oldTimestamp, timestamp)) {
-                    tracing::markTimestampOutOfOrder();
-                    return;
-                }
-            }
             StateMapContents<ReportType> c;
             c.state = reportState(report);
             c.timestamp = timestamp;


### PR DESCRIPTION
It was breaking use cases when the data stream had non-monotonic time stamps - such as a looping pre-recorded sequence.

Fixes https://github.com/OSVR/OSVR-Core/issues/326