### PR TITLE
Idle server

### DIFF
--- a/inc/osvr/Common/CommonComponent.h
+++ b/inc/osvr/Common/CommonComponent.h
@@ -44,31 +44,31 @@ namespace common {
     namespace messages {
         class VRPNPing : public MessageRegistration<VRPNPing> {
           public:
-            static const char *identifier();
+            OSVR_COMMON_EXPORT static const char *identifier();
         };
         class VRPNPong : public MessageRegistration<VRPNPong> {
           public:
-            static const char *identifier();
+            OSVR_COMMON_EXPORT static const char *identifier();
         };
         class VRPNGotFirstConnection
             : public MessageRegistration<VRPNGotFirstConnection> {
           public:
-            static const char *identifier();
+            OSVR_COMMON_EXPORT static const char *identifier();
         };
         class VRPNGotConnection
             : public MessageRegistration<VRPNGotConnection> {
           public:
-            static const char *identifier();
+            OSVR_COMMON_EXPORT static const char *identifier();
         };
         class VRPNDroppedConnection
             : public MessageRegistration<VRPNDroppedConnection> {
           public:
-            static const char *identifier();
+            OSVR_COMMON_EXPORT static const char *identifier();
         };
         class VRPNDroppedLastConnection
             : public MessageRegistration<VRPNDroppedLastConnection> {
           public:
-            static const char *identifier();
+            OSVR_COMMON_EXPORT static const char *identifier();
         };
 
         /// List of message types used in the CommonComponent that share the

--- a/inc/osvr/Common/CommonComponent.h
+++ b/inc/osvr/Common/CommonComponent.h
@@ -48,6 +48,26 @@ namespace common {
           public:
             static const char *identifier();
         };
+        class VRPNGotFirstConnection
+            : public MessageRegistration<VRPNGotFirstConnection> {
+          public:
+            static const char *identifier();
+        };
+        class VRPNGotConnection
+            : public MessageRegistration<VRPNGotConnection> {
+          public:
+            static const char *identifier();
+        };
+        class VRPNDroppedConnection
+            : public MessageRegistration<VRPNDroppedConnection> {
+          public:
+            static const char *identifier();
+        };
+        class VRPNDroppedLastConnection
+            : public MessageRegistration<VRPNDroppedLastConnection> {
+          public:
+            static const char *identifier();
+        };
     } // namespace messages
     /// @brief BaseDevice component, for the VRPN built-in common messages
     class CommonComponent : public DeviceComponent {

--- a/inc/osvr/Common/CommonComponent.h
+++ b/inc/osvr/Common/CommonComponent.h
@@ -29,6 +29,8 @@
 #include <osvr/Common/CommonComponent_fwd.h>
 #include <osvr/Common/Export.h>
 #include <osvr/Common/DeviceComponent.h>
+#include <osvr/TypePack/List.h>
+#include <osvr/TypePack/TypeKeyedMap.h>
 
 // Library/third-party includes
 // - none
@@ -68,6 +70,13 @@ namespace common {
           public:
             static const char *identifier();
         };
+
+        /// List of message types used in the CommonComponent that share the
+        /// same handler behavior, so we can share registration behavior.
+        using CommonComponentMessageTypes =
+            typepack::list<VRPNPing, VRPNPong, VRPNGotFirstConnection,
+                           VRPNGotConnection, VRPNDroppedConnection,
+                           VRPNDroppedLastConnection>;
     } // namespace messages
     /// @brief BaseDevice component, for the VRPN built-in common messages
     class CommonComponent : public DeviceComponent {
@@ -88,20 +97,34 @@ namespace common {
 
         messages::VRPNPong pong;
 
-        /// @brief Register a pong handler: a pong replies to a ping, and  is
+        /// @brief Register a pong handler: a pong replies to a ping, and is
         /// sent from a server device to the corresponding client device.
         OSVR_COMMON_EXPORT void registerPongHandler(Handler const &handler);
 
+        messages::VRPNGotFirstConnection gotFirstConnection;
+        messages::VRPNGotConnection gotConnection;
+        messages::VRPNDroppedConnection droppedConnection;
+        messages::VRPNDroppedLastConnection droppedLastConnection;
+
+        template <typename T>
+        void registerHandler(MessageRegistration<T> const &message,
+                             Handler const &handler) {
+            auto &handlers = typepack::get<T>(m_handlers);
+            if (handlers.empty()) {
+                m_registerHandler(&CommonComponent::m_baseHandler, &handlers,
+                                  message.getMessageType());
+            }
+            handlers.push_back(handler);
+        }
+
       private:
         CommonComponent();
-        virtual void m_parentSet();
-        static int VRPN_CALLBACK
-        m_handlePing(void *userdata, vrpn_HANDLERPARAM);
-        static int VRPN_CALLBACK
-        m_handlePong(void *userdata, vrpn_HANDLERPARAM);
+        void m_parentSet() override;
 
-        std::vector<Handler> m_pingHandlers;
-        std::vector<Handler> m_pongHandlers;
+        static int VRPN_CALLBACK m_baseHandler(void *userdata,
+                                               vrpn_HANDLERPARAM);
+        typepack::TypeKeyedMap<messages::CommonComponentMessageTypes,
+                               std::vector<Handler>> m_handlers;
     };
 } // namespace common
 } // namespace osvr

--- a/inc/osvr/Common/CommonComponent.h
+++ b/inc/osvr/Common/CommonComponent.h
@@ -110,19 +110,22 @@ namespace common {
         void registerHandler(MessageRegistration<T> const &message,
                              Handler const &handler) {
             auto &handlers = typepack::get<T>(m_handlers);
-            if (handlers.empty()) {
-                m_registerHandler(&CommonComponent::m_baseHandler, &handlers,
-                                  message.getMessageType());
-            }
-            handlers.push_back(handler);
+            m_registerHandlerImpl(handlers, message.getMessageType(), handler);
         }
 
       private:
         CommonComponent();
         void m_parentSet() override;
 
+        using HandlerList = std::vector<Handler>;
+        OSVR_COMMON_EXPORT void
+        m_registerHandlerImpl(HandlerList &handlers,
+                              osvr::common::RawMessageType rawMessageType,
+                              Handler const &handler);
+
         static int VRPN_CALLBACK m_baseHandler(void *userdata,
                                                vrpn_HANDLERPARAM);
+
         typepack::TypeKeyedMap<messages::CommonComponentMessageTypes,
                                std::vector<Handler>> m_handlers;
     };

--- a/inc/osvr/Server/Server.h
+++ b/inc/osvr/Server/Server.h
@@ -218,7 +218,8 @@ namespace server {
             std::string const &server, std::string const &descriptor);
 
         /// @brief Sets the amount of time (in microseconds) that the server
-        /// loop will sleep each loop.
+        /// loop will sleep each loop when a client is connected (0 means no
+        /// sleep)
         ///
         /// Call only before starting the server or from within server thread.
         OSVR_SERVER_EXPORT void setSleepTime(int microseconds);

--- a/inc/osvr/Server/Server.h
+++ b/inc/osvr/Server/Server.h
@@ -223,12 +223,13 @@ namespace server {
         /// Call only before starting the server or from within server thread.
         OSVR_SERVER_EXPORT void setSleepTime(int microseconds);
 
+#if 0
         /// @brief Returns the amount of time (in microseconds) that the server
         /// loop sleeps each loop.
         ///
         /// Call only before starting the server or from within server thread.
         OSVR_SERVER_EXPORT int getSleepTime() const;
-
+#endif
       private:
         unique_ptr<ServerImpl> m_impl;
     };

--- a/src/osvr/Common/CommonComponent.cpp
+++ b/src/osvr/Common/CommonComponent.cpp
@@ -61,36 +61,30 @@ namespace common {
     }
 
     void CommonComponent::registerPingHandler(Handler const &handler) {
-        if (m_pingHandlers.empty()) {
-            m_registerHandler(&CommonComponent::m_handlePing, this,
-                              ping.getMessageType());
-        }
-        m_pingHandlers.push_back(handler);
+        /// Just forward to the templated implementation.
+        registerHandler(ping, handler);
     }
 
     void CommonComponent::registerPongHandler(Handler const &handler) {
-        if (m_pongHandlers.empty()) {
-            m_registerHandler(&CommonComponent::m_handlePing, this,
-                              pong.getMessageType());
-        }
-        m_pongHandlers.push_back(handler);
+        /// Just forward to the templated implementation.
+        registerHandler(pong, handler);
     }
 
     CommonComponent::CommonComponent() {}
     void CommonComponent::m_parentSet() {
         m_getParent().registerMessageType(ping);
         m_getParent().registerMessageType(pong);
+        m_getParent().registerMessageType(gotFirstConnection);
+        m_getParent().registerMessageType(gotConnection);
+        m_getParent().registerMessageType(droppedConnection);
+        m_getParent().registerMessageType(droppedLastConnection);
     }
-    int CommonComponent::m_handlePing(void *userdata, vrpn_HANDLERPARAM) {
-        auto self = static_cast<CommonComponent *>(userdata);
-        for (auto const &cb : self->m_pingHandlers) {
-            cb();
-        }
-        return 0;
-    }
-    int CommonComponent::m_handlePong(void *userdata, vrpn_HANDLERPARAM) {
-        auto self = static_cast<CommonComponent *>(userdata);
-        for (auto const &cb : self->m_pongHandlers) {
+
+    int CommonComponent::m_baseHandler(void *userdata, vrpn_HANDLERPARAM) {
+        /// Our userdata here is a pointer to a vector of handlers - it doesn't
+        /// matter to us what kind.
+        auto &handlers = *static_cast<std::vector<Handler> *>(userdata);
+        for (auto const &cb : handlers) {
             cb();
         }
         return 0;

--- a/src/osvr/Common/CommonComponent.cpp
+++ b/src/osvr/Common/CommonComponent.cpp
@@ -70,6 +70,16 @@ namespace common {
         registerHandler(pong, handler);
     }
 
+    void CommonComponent::m_registerHandlerImpl(
+        HandlerList &handlers, osvr::common::RawMessageType rawMessageType,
+        Handler const &handler) {
+        if (handlers.empty()) {
+            m_registerHandler(&CommonComponent::m_baseHandler, &handlers,
+                              rawMessageType);
+        }
+        handlers.push_back(handler);
+    }
+
     CommonComponent::CommonComponent() {}
     void CommonComponent::m_parentSet() {
         m_getParent().registerMessageType(ping);

--- a/src/osvr/Common/CommonComponent.cpp
+++ b/src/osvr/Common/CommonComponent.cpp
@@ -36,11 +36,17 @@ namespace common {
     namespace messages {
 
         // These messages all must match the ones in VRPN exactly.
-        /// @todo add tests to verify that these message identifiers match VRPN
-        /// string constants.
 
+        /// @todo add test to verify that this matches VRPN: message type string
+        /// not accessible as a constant, so we have to extract the message ID
+        /// instead.
         const char *VRPNPing::identifier() { return "vrpn_Base ping_message"; }
+
+        /// @todo add test to verify that this matches VRPN: message type string
+        /// not accessible as a constant, so we have to extract the message ID
+        /// instead.
         const char *VRPNPong::identifier() { return "vrpn_Base pong_message"; }
+
         const char *VRPNGotFirstConnection::identifier() {
             return "VRPN_Connection_Got_First_Connection";
         }

--- a/src/osvr/Common/CommonComponent.cpp
+++ b/src/osvr/Common/CommonComponent.cpp
@@ -35,8 +35,24 @@ namespace osvr {
 namespace common {
     namespace messages {
 
+        // These messages all must match the ones in VRPN exactly.
+        /// @todo add tests to verify that these message identifiers match VRPN
+        /// string constants.
+
         const char *VRPNPing::identifier() { return "vrpn_Base ping_message"; }
         const char *VRPNPong::identifier() { return "vrpn_Base pong_message"; }
+        const char *VRPNGotFirstConnection::identifier() {
+            return "VRPN_Connection_Got_First_Connection";
+        }
+        const char *VRPNGotConnection::identifier() {
+            return "VRPN_Connection_Got_Connection";
+        }
+        const char *VRPNDroppedConnection::identifier() {
+            return "VRPN_Connection_Dropped_Connection";
+        }
+        const char *VRPNDroppedLastConnection::identifier() {
+            return "VRPN_Connection_Dropped_Last_Connection";
+        }
 
     } // namespace messages
     shared_ptr<CommonComponent> CommonComponent::create() {

--- a/src/osvr/Server/Server.cpp
+++ b/src/osvr/Server/Server.cpp
@@ -110,9 +110,9 @@ namespace server {
     void Server::setSleepTime(int microseconds) {
         m_impl->setSleepTime(microseconds);
     }
-
+#if 0
     int Server::getSleepTime() const { return m_impl->getSleepTime(); }
-
+#endif
     Server::Server(connection::ConnectionPtr const &conn,
                    private_constructor const &)
         : m_impl(new ServerImpl(conn)) {}

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -114,15 +114,9 @@ namespace server {
     }
 
     ServerImpl::~ServerImpl() {
-#if 0
-        vrpnConn->unregister_handler(
-            m_commonComponent->gotFirstConnection.getMessageType().get(),
-            &ServerImpl::m_exitIdle, this);
-        vrpnConn->unregister_handler(
-            m_commonComponent->droppedLastConnection.getMessageType().get(),
-            &ServerImpl::m_enterIdle, this);
-#endif
         stop();
+        // Not unregistering idle handlers because doing so caused crashes, and
+        // I think that this object should outlive the connection anyway.
     }
 
     void ServerImpl::start() {

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -348,9 +348,9 @@ namespace server {
     void ServerImpl::setSleepTime(int microseconds) {
         m_sleepTime = microseconds;
     }
-
+#if 0
     int ServerImpl::getSleepTime() const { return m_sleepTime; }
-
+#endif
     void ServerImpl::m_handleDeviceDescriptors() {
         for (auto const &dev : m_conn->getDevices()) {
             auto const &descriptor = dev->getDeviceDescriptor();

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -378,16 +378,25 @@ namespace server {
 
     int ServerImpl::m_exitIdle(void *userdata, vrpn_HANDLERPARAM) {
         auto self = static_cast<ServerImpl *>(userdata);
-
-        OSVR_DEV_VERBOSE("Got first client connection, exiting idle mode.");
-        self->m_currentSleepTime = self->m_sleepTime;
+        /// Conditional ensures that we don't "idle" faster than we run: Make
+        /// sure we're sleeping longer now than we will be once we exit idle.
+        if (self->m_currentSleepTime > self->m_sleepTime) {
+            OSVR_DEV_VERBOSE("Got first client connection, exiting idle mode.");
+            self->m_currentSleepTime = self->m_sleepTime;
+        }
         return 0;
     }
 
     int ServerImpl::m_enterIdle(void *userdata, vrpn_HANDLERPARAM) {
         auto self = static_cast<ServerImpl *>(userdata);
-        OSVR_DEV_VERBOSE("Dropped last client connection, entering idle mode.");
-        self->m_currentSleepTime = IDLE_SLEEP_TIME;
+
+        /// Conditional ensures that we don't "idle" faster than we run: Make
+        /// sure we're sleeping shorter now than we will be once we enter idle.
+        if (self->m_currentSleepTime < IDLE_SLEEP_TIME) {
+            OSVR_DEV_VERBOSE(
+                "Dropped last client connection, entering idle mode.");
+            self->m_currentSleepTime = IDLE_SLEEP_TIME;
+        }
         return 0;
     }
 

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -65,8 +65,7 @@ namespace server {
         return ret;
     }
     ServerImpl::ServerImpl(connection::ConnectionPtr const &conn)
-        : m_conn(conn), m_ctx(make_shared<pluginhost::RegistrationContext>()),
-          m_systemComponent(nullptr), m_running(false), m_sleepTime(0) {
+        : m_conn(conn), m_ctx(make_shared<pluginhost::RegistrationContext>()) {
         if (!m_conn) {
             throw std::logic_error(
                 "Can't pass a null ConnectionPtr into Server constructor!");

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -178,6 +178,11 @@ namespace server {
         /// or effectively so)
         bool m_inServerThread() const;
 
+        /// @brief Callback on getting first connection, to exit idle state.
+        static int VRPN_CALLBACK m_exitIdle(void *userdata, vrpn_HANDLERPARAM);
+        /// @brief Callback on dropping last connection, to enter idle state.
+        static int VRPN_CALLBACK m_enterIdle(void *userdata, vrpn_HANDLERPARAM);
+
         /// @brief Connection ownership.
         connection::ConnectionPtr m_conn;
 
@@ -225,6 +230,16 @@ namespace server {
         /// @brief Number of microseconds to sleep after each loop iteration
         /// when at least one client is connected. 0 = no sleeping.
         int m_sleepTime = 0;
+
+        /// @brief Number of microseconds to sleep after each loop iteration
+        /// when no clients are connected.
+        ///
+        /// This is 1 millisecond, the minimum sleep resolution on Windows.
+        static const int IDLE_SLEEP_TIME = 1000;
+
+        /// @brief Number of microseconds to sleep after each loop iteration
+        /// right now. 0 = no sleeping.
+        int m_currentSleepTime = IDLE_SLEEP_TIME;
     };
 
     /// @brief Class to temporarily (in RAII style) change a thread ID variable

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -114,10 +114,10 @@ namespace server {
 
         /// @copydoc Server::setSleepTime()
         void setSleepTime(int microseconds);
-
+#if 0
         /// @copydoc Server::getSleepTime()
         int getSleepTime() const;
-
+#endif
         /// @copydoc Server::instantiateDriver()
         void instantiateDriver(std::string const &plugin,
                                std::string const &driver,

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -191,10 +191,10 @@ namespace server {
         common::BaseDevicePtr m_systemDevice;
 
         /// @brief System device component
-        common::SystemComponent *m_systemComponent;
+        common::SystemComponent *m_systemComponent = nullptr;
 
         /// @brief Common component for system device
-        common::CommonComponent *m_commonComponent;
+        common::CommonComponent *m_commonComponent = nullptr;
 
         /// @brief a flag to indicate whether we should run a hardware
         /// detection.
@@ -214,7 +214,7 @@ namespace server {
         /// @{
         boost::thread m_thread;
         ::util::RunLoopManagerBoost m_run;
-        bool m_running;
+        bool m_running = false;
         bool m_everStarted = false;
         /// @}
 
@@ -222,8 +222,9 @@ namespace server {
         /// m_thread.get_id() but a callControlled might change it.
         mutable boost::thread::id m_mainThreadId;
 
-        /// @brief Number of microseconds to sleep after each loop iteration.
-        int m_sleepTime;
+        /// @brief Number of microseconds to sleep after each loop iteration
+        /// when at least one client is connected. 0 = no sleeping.
+        int m_sleepTime = 0;
     };
 
     /// @brief Class to temporarily (in RAII style) change a thread ID variable

--- a/tests/cplusplus/Common/CMakeLists.txt
+++ b/tests/cplusplus/Common/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 add_executable(TestCommon
     DummyTree.h
+    CommonComponent.cpp
     PathTreeResolution.cpp
     RegStringMap.cpp
     Serialization.cpp

--- a/tests/cplusplus/Common/CMakeLists.txt
+++ b/tests/cplusplus/Common/CMakeLists.txt
@@ -23,5 +23,5 @@ add_executable(TestCommon
     "${PROJECT_SOURCE_DIR}/examples/internals/SerializationTraitExample_Complicated.h"
     ${PATHTREEJSON_SOURCES})
 
-target_link_libraries(TestCommon osvrCommon JsonCpp::JsonCpp)
+target_link_libraries(TestCommon osvrCommon JsonCpp::JsonCpp vendored-vrpn)
 osvr_setup_gtest(TestCommon)

--- a/tests/cplusplus/Common/CommonComponent.cpp
+++ b/tests/cplusplus/Common/CommonComponent.cpp
@@ -1,0 +1,56 @@
+/** @file
+    @brief Test Implementation
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Common/CommonComponent.h>
+#include <vrpn_Connection.h>
+
+// Library/third-party includes
+#include "gtest/gtest.h"
+
+// Standard includes
+// - none
+
+namespace messages = osvr::common::messages;
+
+TEST(CommonComponentMessages, GotFirstConnection) {
+    ASSERT_STREQ(messages::VRPNGotFirstConnection::identifier(),
+                 vrpn_got_first_connection);
+}
+
+TEST(CommonComponentMessages, GotConnection) {
+    ASSERT_STREQ(messages::VRPNGotConnection::identifier(),
+                 vrpn_got_connection);
+}
+
+TEST(CommonComponentMessages, DroppedConnection) {
+    ASSERT_STREQ(messages::VRPNDroppedConnection::identifier(),
+                 vrpn_dropped_connection);
+}
+
+TEST(CommonComponentMessages, DroppedLastConnection) {
+    ASSERT_STREQ(messages::VRPNDroppedLastConnection::identifier(),
+                 vrpn_dropped_last_connection);
+}


### PR DESCRIPTION
This pull request adds some CommonComponent functionality that might be suitable for future use by devices to idle themselves. (In a fake-out, I thought I'd be able to use it to idle the whole server, but I was mistaken.)

It also contains the code to idle the whole server - that is, if we have no clients connected (not counting internal/analysis clients), we set our sleep to 1 millisecond (ends up being more than that, but...) - incurring a bit of latency but saving a lot of CPU time. As soon as the first client connects, and until the last connection drops, our sleep goes back down to the configured value (which defaults to 0 - no sleep) for performance and low latency.