### PR TITLE
Change default config on win

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,32 +17,60 @@ before_install:
   - if [ $TRAVIS_OS_NAME = 'linux' -a $CC = 'clang' ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
   - $CC -v
   - if [ $TRAVIS_OS_NAME = 'linux' ]; then export INSTPRF=$HOME/p; mkdir -p $INSTPRF; fi
+  - if [ $TRAVIS_OS_NAME = 'linux' ]; then export OPENCV_VER=3.0.0; fi
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap homebrew/science; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap d235j/osvr; fi"
+  - "if [ $TRAVIS_OS_NAME = 'linux' ]; then if [ $CONFIG = 'Release' ]; then
+       export DEPSDIR=deps-rel;
+     else
+       export DEPSDIR=deps-dbg;
+     fi; fi"
   - "if [ $TRAVIS_OS_NAME = 'linux' ]; then
       pushd $HOME;
-      git clone https://github.com/OSVR/libfunctionality.git;
-      git clone https://github.com/open-source-parsers/jsoncpp.git;
+        mkdir -p $DEPSDIR;
+        cd $DEPSDIR;
+        if [ -d jsoncpp ]; then
+          pushd jsoncpp;
+          git pull;
+          popd;
+        else
+          git clone https://github.com/vrpn/jsoncpp.git -b 0.y.z;
+        fi;
+        if [ -d libfunctionality ]; then
+          pushd libfunctionality;
+            git pull;
+          popd;
+        else
+          git clone https://github.com/OSVR/libfunctionality.git;
+        fi;
+        if [ ! -d opencv-${OPENCV_VER} ]; then
+          curl -LR https://github.com/Itseez/opencv/archive/${OPENCV_VER}.zip -o opencv-${OPENCV_VER}.zip;
+          unzip opencv-${OPENCV_VER}.zip;
+        fi;
       popd;
     fi"
 install:
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew uninstall json-c; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install libusb opencv; fi"
-  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install jsoncpp --HEAD; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install jsoncpp; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install libfunctionality --HEAD; fi"
   - "if [ $TRAVIS_OS_NAME = 'linux' ]; then
-      mkdir -p $HOME/libfunctionality/build;
-      pushd $HOME/libfunctionality/build;
-      cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG};
-      make -j2 install;
-      popd;
-    fi"
-  - "if [ $TRAVIS_OS_NAME = 'linux' ]; then
-      mkdir $HOME/jsoncpp/build;
-      pushd $HOME/jsoncpp/build;
-      cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=ON -DJSONCPP_WITH_CMAKE_PACKAGE=on -DCMAKE_BUILD_TYPE=${CONFIG};
-      make -j2 install;
+      pushd $HOME/$DEPSDIR;
+        mkdir -p libfunctionality/build;
+        pushd libfunctionality/build;
+          cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG};
+          make -j2 install;
+        popd;
+        mkdir -p jsoncpp/build;
+        pushd jsoncpp/build;
+          cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG} -DBUILD_STATIC_LIBS=OFF -DBUILD_SHARED_LIBS=ON -DJSONCPP_WITH_CMAKE_PACKAGE=ON;
+          make -j2 install;
+        popd;
+        mkdir -p opencv-${OPENCV_VER}/build;
+        pushd opencv-${OPENCV_VER}/build;
+          cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG} -DWITH_IPP=OFF -DWITH_1394=OFF -DWITH_FFMPEG=OFF;
+          make -j2 install;
       popd;
     fi"
 script:
@@ -50,7 +78,7 @@ script:
   - "mkdir build;"
   - "cd build;"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then cmake .. -DCMAKE_BUILD_TYPE=${CONFIG} -DCMAKE_OSX_ARCHITECTURES=x86_64; fi"
-  - "if [ $TRAVIS_OS_NAME = 'linux' ]; then cmake .. -DCMAKE_BUILD_TYPE=${CONFIG} -DCMAKE_PREFIX_PATH=$INSTPRF; fi"
+  - "if [ $TRAVIS_OS_NAME = 'linux' ]; then cmake .. -DCMAKE_PREFIX_PATH=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG}; fi"
   - "make all -j2"
 # TODO need to sort out false-failures due to container/platform issues.
 #  - "ctest -V"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
           git pull;
           popd;
         else
-          git clone https://github.com/vrpn/jsoncpp.git -b 0.y.z;
+          git clone https://github.com/open-source-parsers/jsoncpp.git;
         fi;
         if [ -d libfunctionality ]; then
           pushd libfunctionality;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
   exclude:
   - os: osx
     compiler: gcc
+cache:
+  directories:
+    $HOME/deps-rel
+    $HOME/deps-dbg
 before_install:
   - if [ $CC = gcc ]; then export CXX="g++-5" CC="gcc-5"; fi
   - if [ $TRAVIS_OS_NAME = 'linux' -a $CC = 'clang' ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ install:
         mkdir -p opencv-${OPENCV_VER}/build;
         pushd opencv-${OPENCV_VER}/build;
           cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG} \
-            -DWITH_1394=OFF -DWITH_FFMPEG=OFF -DWITH_IPP=OFF -WITH_WEBP=OFF \
+            -DWITH_1394=OFF -DWITH_FFMPEG=OFF -DWITH_IPP=OFF -DWITH_WEBP=OFF \
             -DBUILD_DOCS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF \
             -DBUILD_opencv_apps=OFF -DBUILD_opencv_java=OFF -DBUILD_opencv_python2=OFF \
             -DBUILD_opencv_ts=OFF;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,19 @@ before_install:
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap homebrew/science; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap d235j/osvr; fi"
-  - "if [ $TRAVIS_OS_NAME = 'linux' ]; then if [ $CONFIG = 'Release' ]; then
-       export DEPSDIR=deps-rel;
-     else
-       export DEPSDIR=deps-dbg;
-     fi; fi"
   - "if [ $TRAVIS_OS_NAME = 'linux' ]; then
-      pushd $HOME;
-        mkdir -p $DEPSDIR;
-        cd $DEPSDIR;
+       if [ $CONFIG = 'Release' ]; then
+         export DEPSDIR=$HOME/deps-rel;
+       else
+         export DEPSDIR=$HOME/deps-dbg;
+       fi;
+     fi"
+  - "if [ $TRAVIS_OS_NAME = 'linux' ]; then
+      mkdir -p $DEPSDIR;
+      pushd $DEPSDIR;
         if [ -d jsoncpp ]; then
           pushd jsoncpp;
-          git pull;
+            git pull;
           popd;
         else
           git clone https://github.com/open-source-parsers/jsoncpp.git;
@@ -56,7 +57,7 @@ install:
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install jsoncpp; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install libfunctionality --HEAD; fi"
   - "if [ $TRAVIS_OS_NAME = 'linux' ]; then
-      pushd $HOME/$DEPSDIR;
+      pushd $DEPSDIR;
         mkdir -p libfunctionality/build;
         pushd libfunctionality/build;
           cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG};
@@ -71,6 +72,7 @@ install:
         pushd opencv-${OPENCV_VER}/build;
           cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG} -DWITH_IPP=OFF -DWITH_1394=OFF -DWITH_FFMPEG=OFF;
           make -j2 install;
+        popd;
       popd;
     fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,11 @@ install:
         popd;
         mkdir -p opencv-${OPENCV_VER}/build;
         pushd opencv-${OPENCV_VER}/build;
-          cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG} -DWITH_IPP=OFF -DWITH_1394=OFF -DWITH_FFMPEG=OFF;
+          cmake .. -DCMAKE_INSTALL_PREFIX=$INSTPRF -DCMAKE_BUILD_TYPE=${CONFIG} \
+            -DWITH_1394=OFF -DWITH_FFMPEG=OFF -DWITH_IPP=OFF -WITH_WEBP=OFF \
+            -DBUILD_DOCS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF \
+            -DBUILD_opencv_apps=OFF -DBUILD_opencv_java=OFF -DBUILD_opencv_python2=OFF \
+            -DBUILD_opencv_ts=OFF;
           make -j2 install;
         popd;
       popd;

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,6 @@ addons:
     - llvm-toolchain-precise-3.7
     packages:
     - libusb-1.0-0-dev
-    - libopencv-dev
     - libboost-thread1.55-dev
     - libboost-system1.55-dev
     - libboost-date-time1.55-dev

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -194,7 +194,8 @@ if(BUILD_SERVER_APP)
     set(FILE_OUTPUTS)
 
     # Macro to easily copy for build and install a single file.
-    # Put in a macro because we do different things on Windows vs. other platforms, including installing different number of files.
+    # Put in a macro because we do different things on Windows vs. other platforms,
+    # including installing different number of files.
     macro(osvr_copy_file _infile _outfile)
         list(APPEND FILE_OUTPUTS "${_infile}")
         set(__comment "Copying ${_infile}")

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -193,18 +193,42 @@ if(BUILD_SERVER_APP)
     set(data_installtree_dir ${SAMPLE_CONFIGS_DIR})
     set(FILE_OUTPUTS)
 
-    # Copy/install the default config file from the current directory.
-    set(DEFAULT_CONFIG_FILE osvr_server_config.json)
+    # Macro to easily copy for build and install a single file.
+    # Put in a macro because we do different things on Windows vs. other platforms, including installing different number of files.
+    macro(osvr_copy_file _infile _outfile)
+        list(APPEND FILE_OUTPUTS "${_infile}")
+        set(__comment "Copying ${_infile}")
+        if(NOT "${_infile}" STREQUAL "${_outfile}")
+            set(__comment "${__comment} to ${_outfile}")
+        endif()
+        add_custom_command(OUTPUT "${_infile}"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${_infile}" "${data_buildtree_dir}/${_outfile}"
+            MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${_infile}"
+            ${DEFAULT_CONFIG_EXTRA_ARGS}
+            COMMENT "${__comment}"
+            VERBATIM)
+        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${_infile}"
+            RENAME "${_outfile}"
+            DESTINATION "${data_installtree_dir}" COMPONENT Server)
+    endmacro()
 
-    list(APPEND FILE_OUTPUTS "${DEFAULT_CONFIG_FILE}")
-    add_custom_command(OUTPUT "${DEFAULT_CONFIG_FILE}"
-        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${DEFAULT_CONFIG_FILE}" "${data_buildtree_dir}"
-        MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${DEFAULT_CONFIG_FILE}"
-        ${DEFAULT_CONFIG_EXTRA_ARGS}
-        COMMENT "Copying ${DEFAULT_CONFIG_FILE}"
-        VERBATIM)
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${DEFAULT_CONFIG_FILE}"
-        DESTINATION "${data_installtree_dir}" COMPONENT Server)
+    # The name of the default config file.
+    set(DEFAULT_CONFIG_FILE osvr_server_config.json)
+    # Config file to use by default on Windows
+    set(DEFAULT_CONFIG_FILE_WIN sample-configs/osvr_server_config.HDK13DirectMode.sample.json)
+    # What we should call the normally-default (empty-ish) config file on Windows.
+    set(DEFAULT_CONFIG_FILE_ALTNAME osvr_server_config.autodetectall.json)
+
+    # Copy/install the default config file from the current directory.
+    if(WIN32)
+        # Copy the default empty config file to an alternate name.
+        osvr_copy_file(${DEFAULT_CONFIG_FILE} ${DEFAULT_CONFIG_FILE_ALTNAME})
+        # Copy the designated default config file for Windows to the right name to be the default.
+        osvr_copy_file(${DEFAULT_CONFIG_FILE_WIN} ${DEFAULT_CONFIG_FILE})
+    else()
+        # If we're not Windows, we just use the standard (autoconfiguring) config file.
+        osvr_copy_file(${DEFAULT_CONFIG_FILE} ${DEFAULT_CONFIG_FILE})
+    endif()
 
     # Copy/install subdirectories of JSON files
     osvr_copy_dir(displays *.json ${data_buildtree_dir} ${SAMPLE_CONFIGS_DIR} "JSON display descriptor")

--- a/apps/sample-configs/renderManager.direct.landscape.json
+++ b/apps/sample-configs/renderManager.direct.landscape.json
@@ -1,0 +1,32 @@
+{
+    "meta": {
+        "schemaVersion": 1
+    },
+    "renderManagerConfig": {
+        "directModeEnabled": true,
+        "directDisplayIndex": 0,
+        "directHighPriorityEnabled": true,
+        "numBuffers": 1,
+        "verticalSyncEnabled": false,
+        "verticalSyncBlockRenderingEnabled": true,
+        "renderOverfillFactor": 1.5,
+
+        "window": {
+            "title": "OSVR",
+            "fullScreenEnabled": true,
+            "xPosition": 1920,
+            "yPosition": 0
+        },
+
+        "display": {
+            "rotation": 0,
+            "bitsPerColor": 8
+        },
+
+        "timeWarp": {
+            "enabled": true,
+            "asynchronous": false,
+            "maxMsBeforeVSync": 5
+        }
+    }
+}

--- a/vendor/libcxx-backports/libcxx_backports/stdmakeunique.h
+++ b/vendor/libcxx-backports/libcxx_backports/stdmakeunique.h
@@ -1,0 +1,71 @@
+/** @file
+    @brief Header containing a std::make_unique implementation using extracted
+   code from libc++ file `include/memory`
+
+    @author
+    LLVM Team
+    University of Illinois at Urbana-Champaign
+    <http://llvm.org>
+
+    Extracted from `libc++/include/memory which is dual-licensed under the MIT
+    and the University of Illinois "BSD-Like" licenses.
+
+    Modifications: Portion of header extracted, `_LIBCPP_INLINE_VISIBILITY`
+   macro instantiations removed and `_VSTD` macro instantations replaced with
+   `::std`, and code placed in its own header file with appropriate includes and
+   namespace. Some additional namespace qualification of `::std::` added as
+   required. Automatic clang-format applied.
+
+    Original license header follows.
+*/
+// -*- C++ -*-
+//===-------------------------- memory ------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INCLUDED_stdmakeunique_h_GUID_555E4284_D6E5_4384_C523_67411C391068
+#define INCLUDED_stdmakeunique_h_GUID_555E4284_D6E5_4384_C523_67411C391068
+
+#include <cstddef>
+#include <memory>      // for std::unique_ptr
+#include <type_traits> // for std::remove_extent
+#include <utility>     // for std::forward
+
+namespace libcxx_backports {
+
+template <class _Tp> struct __unique_if {
+    typedef ::std::unique_ptr<_Tp> __unique_single;
+};
+
+template <class _Tp> struct __unique_if<_Tp[]> {
+    typedef ::std::unique_ptr<_Tp[]> __unique_array_unknown_bound;
+};
+
+template <class _Tp, size_t _Np> struct __unique_if<_Tp[_Np]> {
+    typedef void __unique_array_known_bound;
+};
+
+template <class _Tp, class... _Args>
+inline typename __unique_if<_Tp>::__unique_single
+make_unique(_Args &&... __args) {
+    return ::std::unique_ptr<_Tp>(new _Tp(::std::forward<_Args>(__args)...));
+}
+
+template <class _Tp>
+inline typename __unique_if<_Tp>::__unique_array_unknown_bound
+make_unique(size_t __n) {
+    typedef typename ::std::remove_extent<_Tp>::type _Up;
+    return ::std::unique_ptr<_Tp>(new _Up[__n]());
+}
+
+template <class _Tp, class... _Args>
+typename __unique_if<_Tp>::__unique_array_known_bound
+make_unique(_Args &&...) = delete;
+
+} // namespace libcxx_backports
+#endif // INCLUDED_stdmakeunique_h_GUID_555E4284_D6E5_4384_C523_67411C391068


### PR DESCRIPTION
This makes the `osvr_server_config.json` file copied into the build tree and installed into the install tree by default on Windows platforms the HDK 1.3 direct mode config that supports positional tracking, etc. The original file named that in the source is still shipped, just under a different name causing it to not be the default.  On non-windows platforms there should be no change in behaviors.

Snuck in a little fix that should hopefully also fix Travis-CI's whining while I was at it.