### PR TITLE
Plugin search path unique, single plugin instance

### DIFF
--- a/inc/osvr/PluginHost/PluginSpecificRegistrationContext.h
+++ b/inc/osvr/PluginHost/PluginSpecificRegistrationContext.h
@@ -53,14 +53,11 @@ namespace pluginhost {
         /// context. Ownership is transferred to the caller.
         ///
         /// Typically called by a RegistrationContext in the loadPlugin method,
-        /// this
-        /// may also be used for statically-linked "plugins" whether in
-        /// deployment
-        /// or testing.
+        /// this may also be used for statically-linked "plugins" whether in
+        /// deployment or testing.
         ///
         /// @param name The plugin name, conventionally in an
-        /// underscore-delimited
-        /// reverse DNS format.
+        /// underscore-delimited reverse DNS format.
         OSVR_PLUGINHOST_EXPORT static PluginRegPtr
         create(std::string const &name);
 

--- a/inc/osvr/PluginHost/RegistrationContext.h
+++ b/inc/osvr/PluginHost/RegistrationContext.h
@@ -29,6 +29,7 @@
 // Internal Includes
 #include <osvr/PluginHost/RegistrationContext_fwd.h>
 #include <osvr/Util/SharedPtr.h>
+#include <osvr/Util/UniquePtr.h>
 #include <osvr/Util/AnyMap.h>
 #include <osvr/PluginHost/Export.h>
 #include <osvr/PluginHost/PluginSpecificRegistrationContext.h>
@@ -98,6 +99,9 @@ namespace pluginhost {
 
         PluginRegMap m_regMap;
         util::AnyMap m_data;
+        struct Impl;
+        /// Private impl.
+        unique_ptr<Impl> m_impl;
     };
 } // namespace pluginhost
 } // namespace osvr

--- a/inc/osvr/PluginHost/SearchPath.h
+++ b/inc/osvr/PluginHost/SearchPath.h
@@ -46,11 +46,11 @@ namespace pluginhost {
 
     /// Get list of files inside the directory with given extension
     OSVR_PLUGINHOST_EXPORT FileList
-    getAllFilesWithExt(SearchPath dirPath, const std::string &ext);
+    getAllFilesWithExt(SearchPath const &dirPath, const std::string &ext);
 
     /// Given the name of a plugin, find the full path to the plugin library.
     OSVR_PLUGINHOST_EXPORT std::string
-    findPlugin(const std::string &pluginName);
+    findPlugin(SearchPath const &searchPaths, const std::string &pluginName);
 
 } // namespace pluginhost
 } // namespace osvr

--- a/src/osvr/PluginHost/RegistrationContext.cpp
+++ b/src/osvr/PluginHost/RegistrationContext.cpp
@@ -105,9 +105,10 @@ namespace pluginhost {
                                      pluginName);
         }
 
-        const std::string pluginPathNameNoExt =
-            (boost::filesystem::path(pluginPathName).parent_path() /
-             boost::filesystem::path(pluginPathName).stem()).generic_string();
+        const auto pluginPathNameNoExt =
+            (fs::path(pluginPathName).parent_path() /
+             fs::path(pluginPathName).stem())
+                .generic_string();
         PluginRegPtr pluginReg(
             PluginSpecificRegistrationContext::create(pluginName));
         pluginReg->setParent(*this);
@@ -135,10 +136,8 @@ namespace pluginhost {
         // Load all of the non-.manualload plugins
         for (const auto &plugin : pluginPathNames) {
             OSVR_DEV_VERBOSE("Examining plugin '" << plugin << "'...");
-            const std::string pluginBaseName = boost::filesystem::path(plugin)
-                                                   .filename()
-                                                   .stem()
-                                                   .generic_string();
+            const auto pluginBaseName =
+                fs::path(plugin).filename().stem().generic_string();
             if (boost::iends_with(pluginBaseName, OSVR_PLUGIN_IGNORE_SUFFIX)) {
                 OSVR_DEV_VERBOSE(
                     "Ignoring manual-load plugin: " << pluginBaseName);

--- a/src/osvr/PluginHost/RegistrationContext.cpp
+++ b/src/osvr/PluginHost/RegistrationContext.cpp
@@ -57,6 +57,12 @@ namespace pluginhost {
         }
     }
 
+    template <typename MapType>
+    static inline bool isPluginLoaded(MapType const &regMap,
+                                      std::string const &pluginName) {
+        return (regMap.find(pluginName) != end(regMap));
+    }
+
     static inline bool tryLoadingPlugin(libfunc::PluginHandle &plugin,
                                         std::string const &name,
                                         OSVR_PluginRegContext ctx,
@@ -77,6 +83,11 @@ namespace pluginhost {
     }
 
     void RegistrationContext::loadPlugin(std::string const &pluginName) {
+        if (isPluginLoaded(m_regMap, pluginName)) {
+            throw std::runtime_error("Already loaded a plugin named " +
+                                     pluginName);
+        }
+
         const std::string pluginPathName = pluginhost::findPlugin(pluginName);
         if (pluginPathName.empty()) {
             throw std::runtime_error("Could not find plugin named " +

--- a/src/osvr/PluginHost/SearchPath.cpp
+++ b/src/osvr/PluginHost/SearchPath.cpp
@@ -120,7 +120,7 @@ namespace pluginhost {
         return paths;
     }
 
-    FileList getAllFilesWithExt(SearchPath dirPath, const std::string &ext) {
+    FileList getAllFilesWithExt(SearchPath const& dirPath, const std::string &ext) {
         FileList filesPaths;
 
         for (const auto &path : dirPath) {
@@ -146,8 +146,7 @@ namespace pluginhost {
         return filesPaths;
     }
 
-    std::string findPlugin(const std::string &pluginName) {
-        auto searchPaths = getPluginSearchPath();
+    std::string findPlugin(SearchPath const &searchPaths, const std::string &pluginName) {
         for (const auto &searchPath : searchPaths) {
             if (!fs::exists(searchPath))
                 continue;

--- a/src/osvr/PluginHost/SearchPath.cpp
+++ b/src/osvr/PluginHost/SearchPath.cpp
@@ -34,12 +34,18 @@
 
 // Standard includes
 #include <vector>
+#include <string>
+#include <algorithm>
 
 namespace osvr {
 namespace pluginhost {
+
+    using boost::filesystem::directory_iterator;
+    using boost::make_iterator_range;
+    namespace fs = boost::filesystem;
+
     SearchPath getPluginSearchPath() {
-        using boost::filesystem::path;
-        auto exeLocation = path{getBinaryLocation()};
+        auto exeLocation = fs::path{getBinaryLocation()};
 #ifdef __ANDROID__
         OSVR_DEV_VERBOSE("Binary location: " << exeLocation);
 #endif
@@ -60,21 +66,32 @@ namespace pluginhost {
 
         // binDir now normalized to PREFIX/bin
 
+        /// This will become our return value.
         SearchPath paths;
+
+        // Lambda to add a path, if it's not already in the list.
+        auto addUniquePath = [&paths](fs::path const &path) {
+            OSVR_DEV_VERBOSE("Adding search path " << path);
+            auto pathString = path.generic_string();
+            if (std::find(begin(paths), end(paths), pathString) == end(paths)) {
+                // if we didn't already add this path, add it now.
+                paths.emplace_back(std::move(pathString));
+            }
+        };
 
 #ifdef OSVR_PLUGINS_UNDER_BINDIR
         // If the plugin directory is a subdirectory of where the binaries are,
         // no need to go up a level before searching.
-        paths.push_back((binDir / OSVR_PLUGIN_SUBDIR).string());
+        addUniquePath(binDir / OSVR_PLUGIN_SUBDIR);
 #endif
 
         // For each component of the compiled-in binary directory, we lop off a
         // component from the binary location we've detected, and add it to the
         // list of possible roots.
         auto root = binDir.parent_path();
-        std::vector<path> rootDirCandidates;
+        std::vector<fs::path> rootDirCandidates;
         {
-            auto compiledBinDir = path{OSVR_BINDIR};
+            auto compiledBinDir = fs::path{OSVR_BINDIR};
             do {
                 rootDirCandidates.push_back(root);
                 root = root.parent_path();
@@ -86,18 +103,16 @@ namespace pluginhost {
         // current working directory, if different from root
         auto currentWorkingDirectory = boost::filesystem::current_path();
         if (currentWorkingDirectory != root) {
-            paths.push_back(
-                (currentWorkingDirectory / OSVR_PLUGIN_DIR).string());
+            addUniquePath(currentWorkingDirectory / OSVR_PLUGIN_DIR);
         }
 #endif
 
         for (auto const &possibleRoot : rootDirCandidates) {
 
 #if defined(_MSC_VER) && defined(CMAKE_INTDIR)
-            paths.push_back(
-                (possibleRoot / OSVR_PLUGIN_DIR / CMAKE_INTDIR).string());
+            addUniquePath(possibleRoot / OSVR_PLUGIN_DIR / CMAKE_INTDIR);
 #endif
-            paths.push_back((possibleRoot / OSVR_PLUGIN_DIR).string());
+            addUniquePath(possibleRoot / OSVR_PLUGIN_DIR);
         }
 
         /// @todo add user's home directory to search path
@@ -109,21 +124,20 @@ namespace pluginhost {
         FileList filesPaths;
 
         for (const auto &path : dirPath) {
-            using boost::filesystem::directory_iterator;
-            using boost::make_iterator_range;
-            boost::filesystem::path directoryPath(path);
+            fs::path directoryPath(path);
 
             // Make sure that directory exists
-            if (!boost::filesystem::exists(directoryPath)) {
+            if (!fs::exists(directoryPath)) {
                 continue;
             }
 
             // Get a list of files inside the dir that match the extension
             for (const auto &pathName : make_iterator_range(
                      directory_iterator(directoryPath), directory_iterator())) {
-                if (!boost::filesystem::is_regular_file(pathName) ||
-                    pathName.path().extension() != ext)
+                if (!fs::is_regular_file(pathName) ||
+                    pathName.path().extension() != ext) {
                     continue;
+                }
 
                 filesPaths.push_back(pathName.path().generic_string());
             }
@@ -135,21 +149,17 @@ namespace pluginhost {
     std::string findPlugin(const std::string &pluginName) {
         auto searchPaths = getPluginSearchPath();
         for (const auto &searchPath : searchPaths) {
-            if (!boost::filesystem::exists(searchPath))
+            if (!fs::exists(searchPath))
                 continue;
-
-            using boost::filesystem::directory_iterator;
-            using boost::make_iterator_range;
 
             for (const auto &pluginPathName : make_iterator_range(
                      directory_iterator(searchPath), directory_iterator())) {
                 /// Must be a regular file
                 /// @todo does this mean symlinks get excluded?
-                if (!boost::filesystem::is_regular_file(pluginPathName))
+                if (!fs::is_regular_file(pluginPathName))
                     continue;
 
-                const auto pluginCandidate =
-                    boost::filesystem::path(pluginPathName);
+                const auto pluginCandidate = fs::path(pluginPathName);
 
                 /// Needs right extension
                 if (pluginCandidate.extension().generic_string() !=


### PR DESCRIPTION
Greg, Kevin, and I identified some issues with plugin loading - that we may have been loading plugins multiple times for a number of reasons (paths being present on the plugin search path multiple times, not checking to see if a plugin was already loaded by a particular name). This branch fixes those two bugs and should also provide a performance boost to server startup by only populating that search path once instead of 6-10 times (which was being made more expensive with the de-duplication added)