### PR TITLE
Only build osvr_list_usbserial if BUILD_USBSERIALENUM is enabled.

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -244,8 +244,9 @@ if(BUILD_SERVER_APP)
 endif()
 
 # Simple application to list detected USB serial devices
-if(NOT ANDROID)
+if(BUILD_USBSERIALENUM AND NOT ANDROID)
     add_executable(osvr_list_usbserial osvr_list_usbserial.cpp)
+    target_include_directories(osvr_list_usbserial PRIVATE osvr::osvrUSBSerial)
     target_link_libraries(osvr_list_usbserial osvrUSBSerial)
     install(TARGETS osvr_list_usbserial
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
The `osvr_list_usbserial` app fails to build if BUILD_USBSERIALENUM isn't being built and if it can't find the `osvr/USBSerial/USBSerialEnum.h` header file.