### PR TITLE
Calibration tool improvements

### DIFF
--- a/plugins/videobasedtracker/CMakeLists.txt
+++ b/plugins/videobasedtracker/CMakeLists.txt
@@ -122,6 +122,7 @@ if(WIN32)
     set(CALIB_SOURCES
         VideoTrackerCalibrationUtility.cpp
         ConfigurationParser.h
+        CVTwoStepProgressBar.h
         ImageSource.cpp
         ImageSource.h
         ImageSourceFactories.h

--- a/plugins/videobasedtracker/CMakeLists.txt
+++ b/plugins/videobasedtracker/CMakeLists.txt
@@ -78,6 +78,7 @@ set(PLUGIN_SOURCES
     ImageSource.cpp
     ImageSource.h
     ImageSourceFactories.h
+    SetupSensors.h
     FakeImageSource.cpp
     ${OSVR_VIDEOTRACKERSHARED_SOURCES_IO})
 if(WIN32)

--- a/plugins/videobasedtracker/CMakeLists.txt
+++ b/plugins/videobasedtracker/CMakeLists.txt
@@ -127,6 +127,7 @@ if(WIN32)
         ImageSource.cpp
         ImageSource.h
         ImageSourceFactories.h
+        SetupSensors.h
         DirectShowHDKCameraFactory.h
         DirectShowImageSource.cpp
         DirectShowToCV.h

--- a/plugins/videobasedtracker/CVTwoStepProgressBar.h
+++ b/plugins/videobasedtracker/CVTwoStepProgressBar.h
@@ -1,0 +1,110 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_CVTwoStepProgressBar_h_GUID_259E874E_85B4_4AAD_0FDE_BA90B5D9DCD4
+#define INCLUDED_CVTwoStepProgressBar_h_GUID_259E874E_85B4_4AAD_0FDE_BA90B5D9DCD4
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+// Standard includes
+#include <tuple>
+
+namespace osvr {
+namespace vbtracker {
+    void drawTwoStepProgressBar(cv::Mat &image, cv::Point location,
+                                cv::Size size, std::size_t complete,
+                                std::size_t partial, std::size_t incomplete) {
+        static const auto RED = cv::Vec3b{0, 0, 255};
+        static const auto YELLOW = cv::Vec3b{0, 255, 255};
+        static const auto GREEN = cv::Vec3b{0, 255, 0};
+
+        auto totalUnits = complete + partial + incomplete;
+        double totalWidth = size.width;
+
+        /// Helper lambdas to reduce duplicate code. Taking colors as vec3b
+        /// because Scalar has too many implicit conversions.
+
+        /// Most basic, drawing a bar starting at the right place, right height,
+        /// of designated width and color.
+        auto drawBar = [&](int width, cv::Vec3b const &color) {
+            cv::rectangle(image, location,
+                          location + cv::Point(width, size.height),
+                          cv::Scalar(color), CV_FILLED);
+        };
+
+        /// Draw a bar that's a fraction of the total length, based on the units
+        /// passed in (computing the fraction internally), in a given color.
+        auto drawFraction = [&](std::size_t portionOfTotal,
+                                cv::Vec3b const &color) {
+            auto width = double(portionOfTotal) / totalUnits * totalWidth;
+            drawBar(static_cast<int>(width), color);
+        };
+
+        /// Drawing overlapping rectangles to avoid noisy lines at borders. So,
+        /// the bottom one will always be the full size... This we call the
+        /// "base bar"
+        bool haveBaseBar = false;
+        auto drawBaseBar = [&](cv::Vec3b const &color) {
+            drawBar(size.width, color);
+            haveBaseBar = true;
+        };
+
+        using std::make_tuple;
+        /// A list of the layers, bottom to top, with their individual portions
+        /// and their color, to iterate through.
+        auto layers = {
+            make_tuple(incomplete, incomplete + partial + complete, RED),
+            make_tuple(partial, partial + complete, YELLOW),
+            make_tuple(complete, complete, GREEN)};
+
+        /// Iterate through the layers.
+        for (auto &layer : layers) {
+            std::size_t portionOfTotal;
+            std::size_t cumulative;
+            cv::Vec3b color;
+            std::tie(portionOfTotal, cumulative, color) = layer;
+            if (portionOfTotal == 0) {
+                /// skip empty sections
+                continue;
+            }
+
+            if (haveBaseBar) {
+                // Can just draw the fraction if we already have a base
+                // Drawing the cumulative fraction, though, since we overlap.
+                drawFraction(cumulative, color);
+            } else {
+                // Otherwise we get to draw the base.
+                drawBaseBar(color);
+            }
+        }
+    }
+
+} // namespace vbtracker
+} // namespace osvr
+#endif // INCLUDED_CVTwoStepProgressBar_h_GUID_259E874E_85B4_4AAD_0FDE_BA90B5D9DCD4

--- a/plugins/videobasedtracker/SetupSensors.h
+++ b/plugins/videobasedtracker/SetupSensors.h
@@ -125,8 +125,9 @@ namespace vbtracker {
                          "filename "
                       << config.calibrationFile
                       << " was specified, but not found or could not "
-                         "be loaded. This may just mean you have not yet run "
-                         "the optional pre-calibration step."
+                         "be loaded. This is not an error: This may just mean "
+                         "you have not yet run the optional beacon "
+                         "pre-calibration step."
                       << std::endl;
         }
     } // namespace messages

--- a/plugins/videobasedtracker/SetupSensors.h
+++ b/plugins/videobasedtracker/SetupSensors.h
@@ -95,24 +95,12 @@ namespace vbtracker {
     /// known than we might otherwise expect.
     static const double BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED = 0.1;
 
-#if 1
     static bool frontPanelFixedBeaconShared(int id) {
         return (id == 16) || (id == 17) || (id == 19) || (id == 20);
     }
 
-    // to be used by calibration app, to avoid calibrating rear beacons.
-    static bool frontPanelFixedBeaconWithFixedBackPanel(int id) {
-        return (id == 16) || (id == 17) || (id == 19) || (id == 20) ||
-               (id > 34);
-    }
-
     static bool backPanelFixedBeaconShared(int) { return true; }
-#else
-    static const auto frontPanelFixedBeacon = [](int id) {
-        return (id == 16) || (id == 17) || (id == 19) || (id == 20);
-    };
-    static const auto backPanelFixedBeacon = [](int) { return true; };
-#endif
+
     namespace messages {
         inline void loadedCalibFileSuccessfully(ConfigParams const &config) {
             std::cout << "Video-based tracker: Successfully loaded "

--- a/plugins/videobasedtracker/SetupSensors.h
+++ b/plugins/videobasedtracker/SetupSensors.h
@@ -119,13 +119,28 @@ namespace vbtracker {
                       << std::endl;
         }
     } // namespace messages
+
     using BeaconPredicate = std::function<bool(int)>;
 
-    inline void addRearPanelBeaconLocations(ConfigParams const &config,
+    inline std::size_t getNumHDKFrontPanelBeacons() {
+        return OsvrHdkLedLocations_SENSOR0.size();
+    }
+
+    inline std::size_t getNumHDKRearPanelBeacons() {
+        return OsvrHdkLedLocations_SENSOR1.size();
+    }
+    /// distance between front and back panel target origins, in mm.
+    inline double
+    computeDistanceBetweenPanels(double headCircumference,
+                                 double headToFrontBeaconOriginDistance) {
+        return headCircumference / M_PI * 10. + headToFrontBeaconOriginDistance;
+    }
+    inline double computeDistanceBetweenPanels(ConfigParams const &config) {
+        return computeDistanceBetweenPanels(
+            config.headCircumference, config.headToFrontBeaconOriginDistance);
+    }
+    inline void addRearPanelBeaconLocations(double distanceBetweenPanels,
                                             Point3Vector &locations) {
-        // distance between front and back panel target origins, in mm.
-        auto distanceBetweenPanels = config.headCircumference / M_PI * 10. +
-                                     config.headToFrontBeaconOriginDistance;
         // For the back panel beacons: have to rotate 180 degrees
         // about Y, which is the same as flipping sign on X and Z
         // then we must translate along Z by head diameter +
@@ -133,6 +148,12 @@ namespace vbtracker {
         for (auto &pt : OsvrHdkLedLocations_SENSOR1) {
             locations.emplace_back(-pt.x, pt.y, -pt.z - distanceBetweenPanels);
         }
+    }
+
+    inline void addRearPanelBeaconLocations(ConfigParams const &config,
+                                            Point3Vector &locations) {
+        addRearPanelBeaconLocations(computeDistanceBetweenPanels(config),
+                                    locations);
     }
 
     inline void setupSensorsIncludeRearPanel(

--- a/plugins/videobasedtracker/SetupSensors.h
+++ b/plugins/videobasedtracker/SetupSensors.h
@@ -1,0 +1,218 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_SetupSensors_h_GUID_7F0F52BD_57B4_4ABB_0834_C61DB7C22132
+#define INCLUDED_SetupSensors_h_GUID_7F0F52BD_57B4_4ABB_0834_C61DB7C22132
+
+// Internal Includes
+#include "Types.h"
+#include "VideoBasedTracker.h"
+#include "HDKData.h"
+#include "CameraParameters.h"
+#include "HDKLedIdentifierFactory.h"
+
+// Library/third-party includes
+#include <json/value.h>
+#include <json/reader.h>
+
+// Standard includes
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+namespace osvr {
+namespace vbtracker {
+
+    /// @name Helper functions for loading calibration files
+    /// @{
+    inline cv::Point3f parsePoint(Json::Value const &jsonArray) {
+        return cv::Point3f(jsonArray[0].asFloat(), jsonArray[1].asFloat(),
+                           jsonArray[2].asFloat());
+    }
+
+    inline std::vector<cv::Point3f>
+    parseArrayOfPoints(Json::Value const &jsonArray) {
+        /// in case of error, we just return an empty array.
+        std::vector<cv::Point3f> ret;
+        if (!jsonArray.isArray()) {
+            return ret;
+        }
+        for (auto &entry : jsonArray) {
+
+            if (!entry.isArray() || entry.size() != 3) {
+                ret.clear();
+                return ret;
+            }
+            ret.emplace_back(parsePoint(entry));
+        }
+        return ret;
+    }
+
+    inline std::vector<cv::Point3f>
+    tryLoadingArrayOfPointsFromFile(std::string const &filename) {
+        std::vector<cv::Point3f> ret;
+        if (filename.empty()) {
+            return ret;
+        }
+        Json::Value root;
+        {
+            std::ifstream calibfile(filename);
+            if (!calibfile.good()) {
+                return ret;
+            }
+            Json::Reader reader;
+            if (!reader.parse(calibfile, root)) {
+                return ret;
+            }
+        }
+        ret = parseArrayOfPoints(root);
+        return ret;
+    }
+    /// @}
+
+    /// Loading a calibration file means our beacon locations are better
+    /// known than we might otherwise expect.
+    static const double BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED = 0.1;
+
+#if 1
+    static bool frontPanelFixedBeaconShared(int id) {
+        return (id == 16) || (id == 17) || (id == 19) || (id == 20);
+    }
+
+    // to be used by calibration app, to avoid calibrating rear beacons.
+    static bool frontPanelFixedBeaconWithFixedBackPanel(int id) {
+        return (id == 16) || (id == 17) || (id == 19) || (id == 20) ||
+               (id > 34);
+    }
+
+    static bool backPanelFixedBeaconShared(int) { return true; }
+#else
+    static const auto frontPanelFixedBeacon = [](int id) {
+        return (id == 16) || (id == 17) || (id == 19) || (id == 20);
+    };
+    static const auto backPanelFixedBeacon = [](int) { return true; };
+#endif
+    namespace messages {
+        inline void loadedCalibFileSuccessfully(ConfigParams const &config) {
+            std::cout << "Video-based tracker: Successfully loaded "
+                         "beacon calibration file "
+                      << config.calibrationFile << std::endl;
+        }
+
+        inline void calibFileSpecifiedButNotLoaded(ConfigParams const &config) {
+            std::cout << "Video-based tracker: NOTE: Beacon calibration "
+                         "filename "
+                      << config.calibrationFile
+                      << " was specified, but not found or could not "
+                         "be loaded. This may just mean you have not yet run "
+                         "the optional pre-calibration step."
+                      << std::endl;
+        }
+    } // namespace messages
+    using BeaconPredicate = std::function<bool(int)>;
+
+    inline void setupSensorsIncludeRearPanel(
+        VideoBasedTracker &vbtracker, ConfigParams const &config,
+        bool attemptToLoadCalib = true,
+        BeaconPredicate &&beaconFixedPredicate = &frontPanelFixedBeaconShared) {
+
+        // distance between front and back panel target origins, in mm.
+        auto distanceBetweenPanels = config.headCircumference / M_PI * 10. +
+                                     config.headToFrontBeaconOriginDistance;
+
+        Point3Vector locations = OsvrHdkLedLocations_SENSOR0;
+        Vec3Vector directions = OsvrHdkLedDirections_SENSOR0;
+        std::vector<double> variances = OsvrHdkLedVariances_SENSOR0;
+
+        // For the back panel beacons: have to rotate 180 degrees
+        // about Y, which is the same as flipping sign on X and Z
+        // then we must translate along Z by head diameter +
+        // distance from head to front beacon origins
+        for (auto &pt : OsvrHdkLedLocations_SENSOR1) {
+            locations.emplace_back(-pt.x, pt.y, -pt.z - distanceBetweenPanels);
+            variances.push_back(config.backPanelMeasurementError);
+        }
+        // Similarly, rotate the directions.
+        for (auto &vec : OsvrHdkLedDirections_SENSOR1) {
+            directions.emplace_back(-vec[0], vec[1], -vec[2]);
+        }
+        double autocalibScale = 1;
+        if (attemptToLoadCalib) {
+            auto calibLocations =
+                tryLoadingArrayOfPointsFromFile(config.calibrationFile);
+            if (calibLocations.size() == locations.size()) {
+                messages::loadedCalibFileSuccessfully(config);
+                locations = calibLocations;
+                autocalibScale = BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED;
+            } else if (!config.calibrationFile.empty()) {
+                messages::calibFileSpecifiedButNotLoaded(config);
+            }
+        }
+
+        auto camParams = getHDKCameraParameters();
+        vbtracker.addSensor(createHDKUnifiedLedIdentifier(), camParams,
+                            locations, directions, variances,
+                            beaconFixedPredicate, 4, 0, autocalibScale);
+    }
+
+    inline void
+    setupSensorsWithoutRearPanel(VideoBasedTracker &vbtracker,
+                                 ConfigParams const &config,
+                                 bool attemptToLoadCalib = true,
+                                 BeaconPredicate &&frontBeaconFixedPredicate =
+                                     &frontPanelFixedBeaconShared,
+                                 BeaconPredicate &&backBeaconFixedPredicate =
+                                     &backPanelFixedBeaconShared) {
+
+        auto camParams = getHDKCameraParameters();
+
+        bool needFrontSensor = true;
+        if (attemptToLoadCalib) {
+            auto calibLocations =
+                tryLoadingArrayOfPointsFromFile(config.calibrationFile);
+            if (calibLocations.size() == OsvrHdkLedLocations_SENSOR0.size()) {
+                messages::loadedCalibFileSuccessfully(config);
+                needFrontSensor = false;
+                vbtracker.addSensor(
+                    createHDKLedIdentifier(0), camParams, calibLocations,
+                    OsvrHdkLedDirections_SENSOR0, OsvrHdkLedVariances_SENSOR0,
+                    frontBeaconFixedPredicate, 6, 0,
+                    BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED);
+            } else if (!config.calibrationFile.empty()) {
+                messages::calibFileSpecifiedButNotLoaded(config);
+            }
+        }
+        if (needFrontSensor) {
+            vbtracker.addSensor(
+                createHDKLedIdentifier(0), camParams,
+                OsvrHdkLedLocations_SENSOR0, OsvrHdkLedDirections_SENSOR0,
+                OsvrHdkLedVariances_SENSOR0, frontBeaconFixedPredicate, 6, 0);
+        }
+        vbtracker.addSensor(
+            createHDKLedIdentifier(1), camParams, OsvrHdkLedLocations_SENSOR1,
+            OsvrHdkLedDirections_SENSOR1, backBeaconFixedPredicate, 4, 0);
+    }
+} // namespace vbtracker
+} // namespace osvr
+#endif // INCLUDED_SetupSensors_h_GUID_7F0F52BD_57B4_4ABB_0834_C61DB7C22132

--- a/plugins/videobasedtracker/VideoTrackerCalibrationUtility.cpp
+++ b/plugins/videobasedtracker/VideoTrackerCalibrationUtility.cpp
@@ -278,6 +278,7 @@ class TrackerCalibrationApp {
                 outfile << osvr::common::jsonToStyledString(calib);
                 outfile.close();
             }
+            closeWindow();
             out << "Done! Press enter to exit." << endl;
             std::cin.ignore();
         }
@@ -311,6 +312,8 @@ class TrackerCalibrationApp {
         }
         return key;
     }
+
+    void closeWindow() { cv::destroyWindow(windowNameAndInstructions); }
 
   private:
     ImageSourcePtr m_src;

--- a/plugins/videobasedtracker/com_osvr_VideoBasedHMDTracker.cpp
+++ b/plugins/videobasedtracker/com_osvr_VideoBasedHMDTracker.cpp
@@ -32,6 +32,7 @@
 #include <osvr/PluginKit/TrackerInterfaceC.h>
 #include <osvr/PluginKit/AnalogInterfaceC.h>
 #include "HDKData.h"
+#include "SetupSensors.h"
 
 #include "ConfigurationParser.h"
 
@@ -263,53 +264,6 @@ class HardwareDetection {
     osvr::vbtracker::ConfigParams const m_params;
 };
 
-/// @name Helper functions for loading calibration files
-/// @{
-inline cv::Point3f parsePoint(Json::Value const &jsonArray) {
-    return cv::Point3f(jsonArray[0].asFloat(), jsonArray[1].asFloat(),
-                       jsonArray[2].asFloat());
-}
-
-inline std::vector<cv::Point3f>
-parseArrayOfPoints(Json::Value const &jsonArray) {
-    /// in case of error, we just return an empty array.
-    std::vector<cv::Point3f> ret;
-    if (!jsonArray.isArray()) {
-        return ret;
-    }
-    for (auto &entry : jsonArray) {
-
-        if (!entry.isArray() || entry.size() != 3) {
-            ret.clear();
-            return ret;
-        }
-        ret.emplace_back(parsePoint(entry));
-    }
-    return ret;
-}
-
-inline std::vector<cv::Point3f>
-tryLoadingArrayOfPointsFromFile(std::string const &filename) {
-    std::vector<cv::Point3f> ret;
-    if (filename.empty()) {
-        return ret;
-    }
-    Json::Value root;
-    {
-        std::ifstream calibfile(filename);
-        if (!calibfile.good()) {
-            return ret;
-        }
-        Json::Reader reader;
-        if (!reader.parse(calibfile, root)) {
-            return ret;
-        }
-    }
-    ret = parseArrayOfPoints(root);
-    return ret;
-}
-/// @}
-
 class ConfiguredDeviceConstructor {
   public:
     /// @brief This is the required signature for a device instantiation
@@ -390,113 +344,21 @@ class ConfiguredDeviceConstructor {
         /// Function to execute after the device is created, to add the sensors.
         std::function<void(VideoBasedHMDTracker & newTracker)>
             setupHDKParamsAndSensors;
-        /// Loading a calibration file means our beacon locations are better
-        /// known than we might otherwise expect.
-        auto BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED = 0.1;
+
         if (config.includeRearPanel) {
-            // distance between front and back panel target origins, in mm.
-            auto distanceBetweenPanels = config.headCircumference / M_PI * 10. +
-                                         config.headToFrontBeaconOriginDistance;
-            setupHDKParamsAndSensors =
-                [config, distanceBetweenPanels, frontPanelFixedBeacon,
-                 BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED](
-                    VideoBasedHMDTracker &newTracker) {
-                    osvr::vbtracker::Point3Vector locations =
-                        osvr::vbtracker::OsvrHdkLedLocations_SENSOR0;
-                    osvr::vbtracker::Vec3Vector directions =
-                        osvr::vbtracker::OsvrHdkLedDirections_SENSOR0;
-                    std::vector<double> variances =
-                        osvr::vbtracker::OsvrHdkLedVariances_SENSOR0;
-
-                    // For the back panel beacons: have to rotate 180 degrees
-                    // about Y, which is the same as flipping sign on X and Z
-                    // then we must translate along Z by head diameter +
-                    // distance from head to front beacon origins
-                    for (auto &pt :
-                         osvr::vbtracker::OsvrHdkLedLocations_SENSOR1) {
-                        locations.emplace_back(-pt.x, pt.y,
-                                               -pt.z - distanceBetweenPanels);
-                        variances.push_back(config.backPanelMeasurementError);
-                    }
-                    // Similarly, rotate the directions.
-                    for (auto &vec :
-                         osvr::vbtracker::OsvrHdkLedDirections_SENSOR1) {
-                        directions.emplace_back(-vec[0], vec[1], -vec[2]);
-                    }
-                    double autocalibScale = 1;
-                    auto calibLocations =
-                        tryLoadingArrayOfPointsFromFile(config.calibrationFile);
-                    if (calibLocations.size() == locations.size()) {
-                        std::cout << "Video-based tracker: Successfully loaded "
-                                     "beacon calibration file "
-                                  << config.calibrationFile << std::endl;
-                        locations = calibLocations;
-                        autocalibScale =
-                            BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED;
-                    } else if (!config.calibrationFile.empty()) {
-                        std::cout
-                            << "Video-based tracker: NOTE: Beacon calibration "
-                               "filename "
-                            << config.calibrationFile
-                            << " was specified, but not found or could not "
-                               "be loaded."
-                            << std::endl;
-                    }
-
-                    auto camParams = osvr::vbtracker::getHDKCameraParameters();
-                    newTracker.vbtracker().addSensor(
-                        osvr::vbtracker::createHDKUnifiedLedIdentifier(),
-                        camParams, locations, directions, variances,
-                        frontPanelFixedBeacon, 4, 0, autocalibScale);
-                };
+            setupHDKParamsAndSensors = [config](
+                VideoBasedHMDTracker &newTracker) {
+                osvr::vbtracker::setupSensorsIncludeRearPanel(
+                    newTracker.vbtracker(), config);
+            };
         } else {
             // OK, so if we don't have to include the rear panel as part of the
             // single sensor, that's easy.
-            setupHDKParamsAndSensors =
-                [frontPanelFixedBeacon, config, backPanelFixedBeacon,
-                 BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED](
-                    VideoBasedHMDTracker &newTracker) {
-                    auto camParams = osvr::vbtracker::getHDKCameraParameters();
-
-                    auto calibLocations =
-                        tryLoadingArrayOfPointsFromFile(config.calibrationFile);
-                    if (calibLocations.size() ==
-                        osvr::vbtracker::OsvrHdkLedLocations_SENSOR0.size()) {
-                        std::cout << "Video-based tracker: Successfully loaded "
-                                     "beacon calibration file "
-                                  << config.calibrationFile << std::endl;
-
-                        newTracker.vbtracker().addSensor(
-                            osvr::vbtracker::createHDKLedIdentifier(0),
-                            camParams, calibLocations,
-                            osvr::vbtracker::OsvrHdkLedDirections_SENSOR0,
-                            osvr::vbtracker::OsvrHdkLedVariances_SENSOR0,
-                            frontPanelFixedBeacon, 6, 0,
-                            BEACON_AUTOCALIB_ERROR_SCALE_IF_CALIBRATED);
-                    } else {
-                        if (!config.calibrationFile.empty()) {
-                            std::cout
-                                << "Video-based tracker: NOTE: Beacon "
-                                   "calibration filename "
-                                << config.calibrationFile
-                                << " was specified, but not found or could not "
-                                   "be loaded."
-                                << std::endl;
-                        }
-                        newTracker.vbtracker().addSensor(
-                            osvr::vbtracker::createHDKLedIdentifier(0),
-                            camParams,
-                            osvr::vbtracker::OsvrHdkLedLocations_SENSOR0,
-                            osvr::vbtracker::OsvrHdkLedDirections_SENSOR0,
-                            osvr::vbtracker::OsvrHdkLedVariances_SENSOR0,
-                            frontPanelFixedBeacon, 6, 0);
-                    }
-                    newTracker.vbtracker().addSensor(
-                        osvr::vbtracker::createHDKLedIdentifier(1), camParams,
-                        osvr::vbtracker::OsvrHdkLedLocations_SENSOR1,
-                        osvr::vbtracker::OsvrHdkLedDirections_SENSOR1,
-                        backPanelFixedBeacon, 4, 0);
-                };
+            setupHDKParamsAndSensors = [config](
+                VideoBasedHMDTracker &newTracker) {
+                osvr::vbtracker::setupSensorsWithoutRearPanel(
+                    newTracker.vbtracker(), config);
+            };
         }
 
         // OK, now that we have our parameters, create the device.


### PR DESCRIPTION
- Now shows all HMD front target beacons (fixes #370)
- Sensor startup code now shared with tracker itself, so no chance of divergence, and simplifies code in both places.
- Actively disables writing out "calibrated" rear beacon positions, as they'd actually reduce tracking quality there.
- Improved calibration UX: after saving, the OpenCV video window is closed to reveal the console window you have to hit enter in, so it doesn't look like it froze.
- Improved calibration UX: progress bar on the bottom with red yellow and green matching the beacons.
- Improved messaging: less harsh message when it can't find the calibration file on startup, since that's a very common case and totally innocuous. (brought up in #357 and several other places)
- Makes the video tracker plugin more robust to loading calibration files of differing lengths: figures out when it needs to clip off the unneeded rear target, or add a computed rear target, to the loaded locations.