### PR TITLE
Json load enhancements

### DIFF
--- a/src/osvr/Server/ConfigureServer.cpp
+++ b/src/osvr/Server/ConfigureServer.cpp
@@ -43,6 +43,8 @@
 #include <iostream>
 #include <vector>
 
+#undef OSVR_JSON_RESOLUTION_VERBOSE
+
 namespace osvr {
 namespace server {
     namespace detail {
@@ -370,7 +372,9 @@ namespace server {
             return success;
         }
 
+#ifdef OSVR_JSON_RESOLUTION_VERBOSE
         printJsonReferenceResolutionAttempts(refReturn);
+#endif
 
         // OK, got it.
         /// @todo don't style this string!
@@ -397,7 +401,9 @@ namespace server {
             return success;
         }
 
+#ifdef OSVR_JSON_RESOLUTION_VERBOSE
         printJsonReferenceResolutionAttempts(refReturn);
+#endif
 
         // OK, got it
         /// @todo don't style this string!

--- a/src/osvr/Server/JSONResolvePossibleRef.cpp
+++ b/src/osvr/Server/JSONResolvePossibleRef.cpp
@@ -155,6 +155,7 @@ namespace server {
         case FileLoadStatus::FileOpenedAndParsed:
             return "File opened and parsed";
         }
+        return "";
     }
 } // namespace server
 } // namespace osvr

--- a/src/osvr/Server/JSONResolvePossibleRef.h
+++ b/src/osvr/Server/JSONResolvePossibleRef.h
@@ -37,6 +37,27 @@
 
 namespace osvr {
 namespace server {
+    enum class FileLoadStatus {
+        CouldNotOpenFile,
+        CouldNotParseFile,
+        FileOpenedAndParsed
+    };
+    enum class ValueHandledAs { Filename, String, JsonRefToFile, Other };
+    struct FileLoadAttempt {
+        std::string path;
+        FileLoadStatus status;
+        std::string details;
+    };
+    using FileLoadAttempts = std::vector<FileLoadAttempt>;
+
+    struct ResolveRefResult {
+        Json::Value result;
+        bool resolved = false;
+        ValueHandledAs handledAs = ValueHandledAs::Other;
+        FileLoadAttempts fileAttempts;
+    };
+
+    const char *fileLoadStatusToString(FileLoadStatus status);
 
     /// @brief Given an input that might be a filename, might be a JSON
     /// Pointer-style $ref object, and might just directly be an object, return
@@ -55,6 +76,12 @@ namespace server {
                                    bool stringAcceptableResult = false,
                                    std::vector<std::string> const &searchPath =
                                        std::vector<std::string>());
+
+    ResolveRefResult
+    resolvePossibleRefWithDetails(Json::Value const &input,
+                                  bool stringAcceptableResult = false,
+                                  std::vector<std::string> const &searchPath =
+                                      std::vector<std::string>());
 
 } // namespace server
 } // namespace osvr


### PR DESCRIPTION
The primary benefit here is better error messages if you can't load your config/display descriptor/render manager config - since it will distinguish "can't open file" from "can't parse file"