### PR TITLE
Fix jsoncpp

### DIFF
--- a/cmake/FindJsonCpp.cmake
+++ b/cmake/FindJsonCpp.cmake
@@ -174,6 +174,7 @@ if(JSONCPP_IMPORTED_LIBRARY)
 
 	find_package_handle_standard_args(JsonCpp
 		DEFAULT_MSG
+		jsoncpp_DIR
 		JSONCPP_IMPORTED_LIBRARY
 		JSONCPP_IMPORTED_INCLUDE_DIRS)
 endif()

--- a/cmake/FindJsonCpp.cmake
+++ b/cmake/FindJsonCpp.cmake
@@ -108,10 +108,15 @@ if(jsoncpp_FOUND AND NOT "[${jsoncpp_DIR}]" STREQUAL "${JSONCPP_CACHED_JSONCPP_D
 		set(JSONCPP_IMPORTED_LIBRARY jsoncpp_lib CACHE INTERNAL "" FORCE)
 		set(JSONCPP_IMPORTED_LIBRARY_IS_SHARED FALSE CACHE INTERNAL "" FORCE)
 
+	elseif(__jsoncpp_have_jsoncpplib AND __jsoncpp_lib_type STREQUAL "SHARED_LIBRARY")
+		# We were able to figure out the mystery library is shared!
+		set(JSONCPP_IMPORTED_LIBRARY_SHARED jsoncpp_lib CACHE INTERNAL "" FORCE)
+		set(JSONCPP_IMPORTED_LIBRARY jsoncpp_lib CACHE INTERNAL "" FORCE)
+		set(JSONCPP_IMPORTED_LIBRARY_IS_SHARED TRUE CACHE INTERNAL "" FORCE)
+
 	elseif(__jsoncpp_have_jsoncpplib)
 		# One variant, and we have no idea if this is just an old version or if
 		# this is shared based on the target name alone. Hmm.
-		# TODO figure out if this is shared or static?
 		set(JSONCPP_IMPORTED_LIBRARY jsoncpp_lib CACHE INTERNAL "" FORCE)
 	endif()
 

--- a/cmake/FindJsonCpp.cmake
+++ b/cmake/FindJsonCpp.cmake
@@ -69,7 +69,7 @@ if(jsoncpp_FOUND AND NOT "[${jsoncpp_DIR}]" STREQUAL "${JSONCPP_CACHED_JSONCPP_D
 	# If we found something, and it's not the exact same as what we've found before...
 	# NOTE: The contents of this "if" block update only (internal) cache variables!
 	# (since this will only get run the first CMake pass that finds jsoncpp or that finds a different install)
-	message("Updating jsoncpp cache variables!")
+	#message("Updating jsoncpp cache variables!")
 	set(JSONCPP_CACHED_JSONCPP_DIR_DETAILS "[${jsoncpp_DIR}]" CACHE INTERNAL "" FORCE)
 	unset(JSONCPP_IMPORTED_LIBRARY_SHARED)
 	unset(JSONCPP_IMPORTED_LIBRARY_STATIC)

--- a/cmake/FindJsonCpp.cmake
+++ b/cmake/FindJsonCpp.cmake
@@ -63,20 +63,39 @@ set(JSONCPP_FOUND FALSE)
 # and we need to call it at least once every CMake invocation to create the original
 # imported targets, since those don't stick around like cache variables.
 find_package(jsoncpp QUIET NO_MODULE)
-#message("Searching for config file result: jsoncpp_FOUND ${jsoncpp_FOUND}")
 
-if(jsoncpp_FOUND AND NOT "[${jsoncpp_DIR}]" STREQUAL "${JSONCPP_CACHED_JSONCPP_DIR_DETAILS}")
-	# If we found something, and it's not the exact same as what we've found before...
-	# NOTE: The contents of this "if" block update only (internal) cache variables!
-	# (since this will only get run the first CMake pass that finds jsoncpp or that finds a different install)
-	#message("Updating jsoncpp cache variables!")
-	set(JSONCPP_CACHED_JSONCPP_DIR_DETAILS "[${jsoncpp_DIR}]" CACHE INTERNAL "" FORCE)
+if(jsoncpp_FOUND)
+	# Build a string to help us figure out when to invalidate our cache variables.
+	# start with where we found jsoncpp
+	set(__jsoncpp_info_string "[${jsoncpp_DIR}]")
+
+	# part of the string to indicate if we found a real jsoncpp_lib (and what kind)
+	_jsoncpp_check_for_real_jsoncpplib()
+	if(__jsoncpp_have_jsoncpplib)
+		list(APPEND __jsoncpp_info_string "[${__jsoncpp_lib_type}]")
+	else()
+		list(APPEND __jsoncpp_info_string "[]")
+	endif()
+	# part of the string to indicate if we found jsoncpp_lib_static
+	if(TARGET jsoncpp_lib_static)
+		list(APPEND __jsoncpp_info_string "[T]")
+	else()
+		list(APPEND __jsoncpp_info_string "[]")
+	endif()
+endif()
+
+
+# If we found something, and it's not the exact same as what we've found before...
+# NOTE: The contents of this "if" block update only (internal) cache variables!
+# (since this will only get run the first CMake pass that finds jsoncpp or that finds a different/updated install)
+if(jsoncpp_FOUND AND NOT __jsoncpp_info_string STREQUAL "${JSONCPP_CACHED_JSONCPP_DIR_DETAILS}")
+	#message("Updating jsoncpp cache variables! ${__jsoncpp_info_string}")
+	set(JSONCPP_CACHED_JSONCPP_DIR_DETAILS "${__jsoncpp_info_string}" CACHE INTERNAL "" FORCE)
 	unset(JSONCPP_IMPORTED_LIBRARY_SHARED)
 	unset(JSONCPP_IMPORTED_LIBRARY_STATIC)
 	unset(JSONCPP_IMPORTED_LIBRARY)
 	unset(JSONCPP_IMPORTED_INCLUDE_DIRS)
 	unset(JSONCPP_IMPORTED_LIBRARY_IS_SHARED)
-	_jsoncpp_check_for_real_jsoncpplib()
 
 	# if(__jsoncpp_have_jsoncpplib) is equivalent to if(TARGET jsoncpp_lib) except it excludes our
 	# "invented" jsoncpp_lib interface targets, made for convenience purposes after this block.

--- a/cmake/FindJsonCpp.cmake
+++ b/cmake/FindJsonCpp.cmake
@@ -221,6 +221,14 @@ if(JSONCPP_FOUND)
 				INTERFACE_INCLUDE_DIRECTORIES "${JSONCPP_IMPORTED_INCLUDE_DIRS}"
 				INTERFACE_LINK_LIBRARIES "${JSONCPP_IMPORTED_LIBRARY_STATIC}")
 		endif()
+
+		# Hide the stuff we didn't, and no longer, need.
+		if(NOT JsonCpp_LIBRARY)
+			unset(JsonCpp_LIBRARY CACHE)
+		endif()
+		if(NOT JsonCpp_INCLUDE_DIR)
+			unset(JsonCpp_INCLUDE_DIR CACHE)
+		endif()
 	endif()
 
 	set(JSONCPP_LIBRARY ${JSONCPP_IMPORTED_LIBRARY})


### PR DESCRIPTION
This should fix the JsonCpp issues we'd been having since an earlier improvement to the cmake script. Tested on Windows with new and old, 32 and 64 bit libraries, in both shared and static builds, as well as on Linux with both distribution-built (so, ancient and without cmake config file) and newer builds.