### PR TITLE
Add hand-tuned distortion coefficients on the HDK 1.1/1.2

### DIFF
--- a/apps/displays/OSVR_HDK_1_1.json
+++ b/apps/displays/OSVR_HDK_1_1.json
@@ -26,9 +26,12 @@
       }
     ],
     "distortion": {
-      "k1_red": 0,
-      "k1_green": 0,
-      "k1_blue": 0
+      /* Requires up to 27% overfill */
+      "distance_scale_x": 1,
+      "distance_scale_y": 1,
+      "polynomial_coeffs_red": [0, 1, 0, 0.5, 0, -1.15, 0, 9.25, 0, -5 ],
+      "polynomial_coeffs_green": [0, 1, 0, 0.5, 0, -1.15, 0, 9.25, 0, -5 ],
+      "polynomial_coeffs_blue": [0, 1, 0, 0.5, 0, -1.15, 0, 9.25, 0, -5 ]
     },
     "rendering": {
       "right_roll": 0,


### PR DESCRIPTION
Modified HDK 1.1 display config with hand-tuned distortion coefficients. Ignores chromatic aberration.

Should the we provide two display configs? One with and one without pre-distortion?
