### PR TITLE
Logging system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,7 @@
 	path = vendor/UIforETWbins
 	url = https://github.com/OSVR/UIforETWbins.git
 	branch = master
+[submodule "vendor/spdlog"]
+	path = vendor/spdlog
+	url = https://github.com/OSVR/spdlog.git
+	branch = master

--- a/apps/external-devices/device-descriptors/Polhemus_G4.json
+++ b/apps/external-devices/device-descriptors/Polhemus_G4.json
@@ -1,0 +1,13 @@
+{
+    "deviceVendor": "Polhemus",
+    "deviceName": "G4",
+    "author": "Kevin M. Godby <kevin@godby.org>",
+    "version": 1,
+    "lastModified": "2016-04-20T13:41:44Z",
+    "interfaces": {
+        "tracker": {
+            "count": 1
+        }
+    }
+}
+

--- a/apps/external-devices/device-descriptors/Polhemus_PowerTRAK_360.json
+++ b/apps/external-devices/device-descriptors/Polhemus_PowerTRAK_360.json
@@ -1,0 +1,13 @@
+{
+    "deviceVendor": "Polhemus",
+    "deviceName": "PowerTRAK 360",
+    "author": "Kevin M. Godby <kevin@godby.org>",
+    "version": 1,
+    "lastModified": "2016-04-20T13:43:58Z",
+    "interfaces": {
+        "button": {
+            "count": 4
+        }
+    }
+}
+

--- a/apps/osvr_server.cpp
+++ b/apps/osvr_server.cpp
@@ -27,6 +27,7 @@
 #include <osvr/Server/ConfigureServerFromFile.h>
 #include <osvr/Server/RegisterShutdownHandler.h>
 #include <osvr/Util/Log.h>
+#include <osvr/Util/LogNames.h>
 
 // Library/third-party includes
 // - none
@@ -37,22 +38,24 @@
 #include <exception>
 
 static osvr::server::ServerPtr server;
+using ::osvr::util::log::OSVR_SERVER_LOG;
 
 /// @brief Shutdown handler function - forcing the server pointer to be global.
 void handleShutdown() {
-    auto log = ::osvr::util::log::make_logger("OSVR Server");
+    auto log = ::osvr::util::log::make_logger(OSVR_SERVER_LOG);
     log->info() << "Received shutdown signal...";
     server->signalStop();
 }
 
 int main(int argc, char *argv[]) {
-    auto log = ::osvr::util::log::make_logger("OSVR Server");
+    auto log = ::osvr::util::log::make_logger(OSVR_SERVER_LOG);
 
     std::string configName(osvr::server::getDefaultConfigFilename());
     if (argc > 1) {
         configName = argv[1];
     } else {
-        log->info() << "Using default config file - pass a filename on the command "
+        log->info()
+            << "Using default config file - pass a filename on the command "
                "line to use a different one.";
     }
 
@@ -71,4 +74,3 @@ int main(int argc, char *argv[]) {
 
     return 0;
 }
-

--- a/apps/osvr_server.cpp
+++ b/apps/osvr_server.cpp
@@ -26,6 +26,7 @@
 // Internal Includes
 #include <osvr/Server/ConfigureServerFromFile.h>
 #include <osvr/Server/RegisterShutdownHandler.h>
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 // - none
@@ -35,26 +36,24 @@
 #include <fstream>
 #include <exception>
 
-using osvr::server::detail::out;
-using osvr::server::detail::err;
-using std::endl;
-
 static osvr::server::ServerPtr server;
 
 /// @brief Shutdown handler function - forcing the server pointer to be global.
 void handleShutdown() {
-    out << "Received shutdown signal..." << endl;
+    auto log = ::osvr::util::log::make_logger("OSVR Server");
+    log->info() << "Received shutdown signal...";
     server->signalStop();
 }
 
 int main(int argc, char *argv[]) {
+    auto log = ::osvr::util::log::make_logger("OSVR Server");
+
     std::string configName(osvr::server::getDefaultConfigFilename());
     if (argc > 1) {
         configName = argv[1];
     } else {
-        out << "Using default config file - pass a filename on the command "
-               "line to use a different one."
-            << endl;
+        log->info() << "Using default config file - pass a filename on the command "
+               "line to use a different one.";
     }
 
     server = osvr::server::configureServerFromFile(configName);
@@ -62,13 +61,14 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
-    out << "Registering shutdown handler..." << endl;
+    log->info() << "Registering shutdown handler...";
     osvr::server::registerShutdownHandler<&handleShutdown>();
 
-    out << "Starting server mainloop: OSVR Server is ready to go!" << endl;
+    log->info() << "Starting server mainloop: OSVR Server is ready to go!";
     server->startAndAwaitShutdown();
 
-    out << "OSVR Server exited." << endl;
+    log->info() << "OSVR Server exited.";
 
     return 0;
 }
+

--- a/apps/sample-configs/osvr_server_config.renderManager.sample.json
+++ b/apps/sample-configs/osvr_server_config.renderManager.sample.json
@@ -11,6 +11,7 @@
 			"verticalSyncEnabled": false,
 			"verticalSyncBlockRenderingEnabled": true,
 			"renderOverfillFactor": 2.0,
+			"renderOversampleFactor": 1.0,
 			
 			"window": {
 				"title": "OSVR",

--- a/apps/sample-configs/renderManager.direct.portrait.json
+++ b/apps/sample-configs/renderManager.direct.portrait.json
@@ -10,6 +10,7 @@
         "verticalSyncEnabled": false,
         "verticalSyncBlockRenderingEnabled": true,
         "renderOverfillFactor": 1.5,
+        "renderOversampleFactor": 1.0,
 
         "window": {
             "title": "OSVR",

--- a/apps/sample-configs/renderManager.extended.landscape.json
+++ b/apps/sample-configs/renderManager.extended.landscape.json
@@ -10,6 +10,7 @@
         "verticalSyncEnabled": true,
         "verticalSyncBlockRenderingEnabled": true,
         "renderOverfillFactor": 1.5,
+        "renderOversampleFactor": 1.0,
 
         "window": {
             "title": "OSVR",

--- a/apps/sample-configs/renderManager.extended.portrait.json
+++ b/apps/sample-configs/renderManager.extended.portrait.json
@@ -10,6 +10,7 @@
         "verticalSyncEnabled": true,
         "verticalSyncBlockRenderingEnabled": true,
         "renderOverfillFactor": 1.5,
+        "renderOversampleFactor": 1.0,
 
         "window": {
             "title": "OSVR",

--- a/examples/clients/AnalogCallback.c
+++ b/examples/clients/AnalogCallback.c
@@ -59,7 +59,7 @@ int main() {
         osvrClientUpdate(ctx);
     }
 
+    osvrClientLog(ctx, OSVR_LOGLEVEL_NOTICE, "Library shut down, exiting.");
     osvrClientShutdown(ctx);
-    printf("Library shut down, exiting.\n");
     return 0;
 }

--- a/examples/clients/AnalogCallback.cpp
+++ b/examples/clients/AnalogCallback.cpp
@@ -54,6 +54,6 @@ int main() {
         context.update();
     }
 
-    std::cout << "Library shut down, exiting." << std::endl;
+    context.log(OSVR_LOGLEVEL_NOTICE, "Library shut down, exiting.");
     return 0;
 }

--- a/inc/osvr/Client/ClientInterfaceObjectManager.h
+++ b/inc/osvr/Client/ClientInterfaceObjectManager.h
@@ -29,6 +29,7 @@
 #include <osvr/Client/Export.h>
 #include <osvr/Common/ClientInterfacePtr.h>
 #include <osvr/Common/PathTreeObserverPtr.h>
+#include <osvr/Util/Logger.h>
 #include <osvr/Common/PathTree_fwd.h>
 #include <osvr/Common/ClientContext_fwd.h>
 #include <osvr/Client/InterfaceTree.h>
@@ -41,6 +42,7 @@
 
 namespace osvr {
 namespace common {
+    class PathTree;
     class PathTreeOwner;
 } // namespace common
 namespace client {
@@ -92,6 +94,9 @@ namespace client {
         /// @brief Calls m_connectCallbacksOnPath() for every path that has one
         /// or more interface objects but no remote handler.
         void m_connectNeededCallbacks();
+
+        /// @brief Access the client context's logger.
+        util::log::LoggerPtr const &logger() const;
 
         /// @brief Tree parallel to path tree for holding interface objects and
         /// remote handlers.

--- a/inc/osvr/Client/LocateServer.h
+++ b/inc/osvr/Client/LocateServer.h
@@ -27,7 +27,7 @@
 
 
 // Internal Includes
-#include <osvr/Common/GetEnvironmentVariable.h>
+#include <osvr/Util/GetEnvironmentVariable.h>
 #include <osvr/Util/PlatformConfig.h>
 
 // Library/third-party includes
@@ -41,7 +41,7 @@ namespace osvr {
 
         /** @brief INTERNAL ONLY - get the current server directory, if available. */
         inline boost::optional<std::string> getServerBinaryDirectoryPath() {
-            auto server = osvr::common::getEnvironmentVariable("OSVR_SERVER_ROOT");
+            auto server = osvr::util::getEnvironmentVariable("OSVR_SERVER_ROOT");
             return server;
         }
 

--- a/inc/osvr/ClientKit/Context.h
+++ b/inc/osvr/ClientKit/Context.h
@@ -112,6 +112,10 @@ namespace clientkit {
         return osvrClientCheckStatus(m_context) == OSVR_RETURN_SUCCESS;
     }
 
+    inline void ClientContext::log(OSVR_LogLevel severity, const char* message) {
+        osvrClientLog(m_context, severity, message);
+    }
+
 } // end namespace clientkit
 
 } // end namespace osvr

--- a/inc/osvr/ClientKit/ContextC.h
+++ b/inc/osvr/ClientKit/ContextC.h
@@ -93,11 +93,12 @@ osvrClientShutdown(OSVR_ClientContext ctx);
 
 /** @brief Log a message from the client.
  */
-OSVR_CLIENTKIT_EXPORT OSVR_ReturnCode osvrClientLog(OSVR_ClientContext ctx,
-                                                    OSVR_LogLevel severity,
-                                                    const char *message);
+OSVR_CLIENTKIT_EXPORT void osvrClientLog(OSVR_ClientContext ctx,
+                                         OSVR_LogLevel severity,
+                                         const char *message);
 
 /** @} */
 OSVR_EXTERN_C_END
 
-#endif
+#endif /* INCLUDED_ContextC_h_GUID_3790F330_2425_4486_4C9F_20C300D7DED3 */
+

--- a/inc/osvr/ClientKit/ContextC.h
+++ b/inc/osvr/ClientKit/ContextC.h
@@ -38,6 +38,7 @@
 #include <osvr/Util/AnnotationMacrosC.h>
 #include <osvr/Util/StdInt.h>
 #include <osvr/Util/ClientOpaqueTypesC.h>
+#include <osvr/Util/LogLevelC.h>
 
 /* Library/third-party includes */
 /* none */
@@ -89,6 +90,12 @@ osvrClientCheckStatus(OSVR_ClientContext ctx);
 */
 OSVR_CLIENTKIT_EXPORT OSVR_ReturnCode
 osvrClientShutdown(OSVR_ClientContext ctx);
+
+/** @brief Log a message from the client.
+ */
+OSVR_CLIENTKIT_EXPORT OSVR_ReturnCode osvrClientLog(OSVR_ClientContext ctx,
+                                                    OSVR_LogLevel severity,
+                                                    const char *message);
 
 /** @} */
 OSVR_EXTERN_C_END

--- a/inc/osvr/ClientKit/Context_decl.h
+++ b/inc/osvr/ClientKit/Context_decl.h
@@ -36,6 +36,7 @@
 
 // Internal Includes
 #include <osvr/ClientKit/ContextC.h>
+#include <osvr/Util/LogLevelC.h>
 
 // Library/third-party includes
 #include <boost/noncopyable.hpp>
@@ -97,6 +98,12 @@ namespace clientkit {
 
         /// @brief Gets the bare OSVR_ClientContext.
         OSVR_ClientContext get();
+
+        /// @brief Log a message to the plugin-specific channel.
+        ///
+        /// @param severity The severity of the log message.
+        /// @param message The message to be logged.
+        void log(OSVR_LogLevel severity, const char* message);
 
       private:
         OSVR_ClientContext m_context;

--- a/inc/osvr/Common/ClientContext.h
+++ b/inc/osvr/Common/ClientContext.h
@@ -35,6 +35,8 @@
 #include <osvr/Util/KeyedOwnershipContainer.h>
 #include <osvr/Util/UniquePtr.h>
 #include <osvr/Util/SharedPtr.h>
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/Logger.h>
 
 // Library/third-party includes
 #include <boost/noncopyable.hpp>
@@ -114,6 +116,10 @@ struct OSVR_ClientContextObject : boost::noncopyable {
     /// received, etc.)
     OSVR_COMMON_EXPORT bool getStatus() const;
 
+    /// @brief Logs a message from the client.
+    OSVR_COMMON_EXPORT void log(osvr::util::log::LogLevel severity,
+                                const char *message);
+
   protected:
     /// @brief Constructor for derived class use only.
     OSVR_COMMON_EXPORT
@@ -159,6 +165,7 @@ struct OSVR_ClientContextObject : boost::noncopyable {
 
     osvr::util::MultipleKeyedOwnershipContainer m_ownedObjects;
     osvr::common::ClientContextDeleter m_deleter;
+    osvr::util::log::LoggerPtr m_logger;
 };
 
 namespace osvr {

--- a/inc/osvr/Common/ClientContext.h
+++ b/inc/osvr/Common/ClientContext.h
@@ -168,7 +168,11 @@ struct OSVR_ClientContextObject : boost::noncopyable {
 
     osvr::util::MultipleKeyedOwnershipContainer m_ownedObjects;
     osvr::common::ClientContextDeleter m_deleter;
+
+    /// Logger for the use of OSVR libraries on behalf of the client
     osvr::util::log::LoggerPtr m_logger;
+    /// Logger for the client's exclusive use
+    osvr::util::log::LoggerPtr m_clientLogger;
 };
 
 namespace osvr {

--- a/inc/osvr/Common/ClientContext.h
+++ b/inc/osvr/Common/ClientContext.h
@@ -120,6 +120,9 @@ struct OSVR_ClientContextObject : boost::noncopyable {
     OSVR_COMMON_EXPORT void log(osvr::util::log::LogLevel severity,
                                 const char *message);
 
+    /// @brief Provides logger access for related internal classes.
+    OSVR_COMMON_EXPORT osvr::util::log::LoggerPtr const &logger() const;
+
   protected:
     /// @brief Constructor for derived class use only.
     OSVR_COMMON_EXPORT

--- a/inc/osvr/Connection/Connection.h
+++ b/inc/osvr/Connection/Connection.h
@@ -33,6 +33,7 @@
 #include <osvr/Connection/DeviceInitObject.h>
 #include <osvr/Util/DeviceCallbackTypesC.h>
 #include <osvr/PluginHost/RegistrationContext_fwd.h>
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 #include <boost/noncopyable.hpp>
@@ -202,6 +203,7 @@ namespace connection {
       private:
         DeviceList m_devices;
         std::vector<std::function<void()> > m_descriptorHandlers;
+        util::log::LoggerPtr m_log;
     };
 } // namespace connection
 } // namespace osvr

--- a/inc/osvr/PluginHost/PluginSpecificRegistrationContext.h
+++ b/inc/osvr/PluginHost/PluginSpecificRegistrationContext.h
@@ -35,6 +35,8 @@
 #include <osvr/Util/SharedPtr.h>
 #include <osvr/Util/AnyMap_fwd.h>
 #include <osvr/Util/GenericDeleter.h>
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/Logger.h>
 
 // Library/third-party includes
 #include <boost/noncopyable.hpp>
@@ -130,13 +132,23 @@ namespace pluginhost {
         /// @brief Accessor for plugin name.
         OSVR_PLUGINHOST_EXPORT const std::string &getName() const;
 
+        /// @brief Log a message to the plugin-specific channel.
+        ///
+        /// @param severity The severity of the message.
+        /// @param message The message to be logged.
+        OSVR_PLUGINHOST_EXPORT void log(util::log::LogLevel severity,
+                                        const char *message);
+
       protected:
         /// @brief Constructor for derived class use only
         PluginSpecificRegistrationContext(std::string const &name);
 
       private:
         std::string const m_name;
+        osvr::util::log::LoggerPtr m_logger;
     };
+
 } // namespace pluginhost
 } // namespace osvr
+
 #endif // INCLUDED_PluginSpecificRegistrationContext_h_GUID_8C008527_0BF6_408F_3C73_4FE76B77D856

--- a/inc/osvr/PluginHost/RegistrationContext.h
+++ b/inc/osvr/PluginHost/RegistrationContext.h
@@ -31,6 +31,7 @@
 #include <osvr/Util/SharedPtr.h>
 #include <osvr/Util/UniquePtr.h>
 #include <osvr/Util/AnyMap.h>
+#include <osvr/Util/Log.h>
 #include <osvr/PluginHost/Export.h>
 #include <osvr/PluginHost/PluginSpecificRegistrationContext.h>
 
@@ -102,6 +103,7 @@ namespace pluginhost {
         struct Impl;
         /// Private impl.
         unique_ptr<Impl> m_impl;
+        util::log::LoggerPtr m_logger;
     };
 } // namespace pluginhost
 } // namespace osvr

--- a/inc/osvr/PluginKit/PluginKit.h
+++ b/inc/osvr/PluginKit/PluginKit.h
@@ -28,6 +28,7 @@
 // Internal Includes
 #include <osvr/PluginKit/DeviceInterface.h>
 #include <osvr/PluginKit/PluginRegistration.h>
+#include <osvr/Util/LogLevelC.h>
 
 // Library/third-party includes
 // - none
@@ -91,6 +92,14 @@ namespace pluginkit {
         /// @sa ::osvr::pluginkit::registerObjectForDeletion
         template <typename T> T *registerObjectForDeletion(T *obj) {
             return ::osvr::pluginkit::registerObjectForDeletion(m_ctx, obj);
+        }
+
+        /// @brief Log a message to the plugin-specific channel.
+        ///
+        /// @param severity The severity of the log message.
+        /// @param message The message to be logged.
+        void log(OSVR_LogLevel severity, const char* message) {
+            ::osvr::pluginkit::log(m_ctx, severity, message);
         }
 
       private:

--- a/inc/osvr/PluginKit/PluginRegistration.h
+++ b/inc/osvr/PluginKit/PluginRegistration.h
@@ -201,10 +201,7 @@ namespace pluginkit {
 
     inline void log(OSVR_PluginRegContext ctx, OSVR_LogLevel severity,
              const char *message) {
-        OSVR_ReturnCode ret = osvrPluginLog(ctx, severity, message);
-        if (ret != OSVR_RETURN_SUCCESS) {
-            throw std::runtime_error("pluginkit::log() failed!");
-        }
+        osvrPluginLog(ctx, severity, message);
     }
 
 } // namespace pluginkit

--- a/inc/osvr/PluginKit/PluginRegistration.h
+++ b/inc/osvr/PluginKit/PluginRegistration.h
@@ -198,6 +198,15 @@ namespace pluginkit {
         }
     }
     /// @}
+
+    inline void log(OSVR_PluginRegContext ctx, OSVR_LogLevel severity,
+             const char *message) {
+        OSVR_ReturnCode ret = osvrPluginLog(ctx, severity, message);
+        if (ret != OSVR_RETURN_SUCCESS) {
+            throw std::runtime_error("pluginkit::log() failed!");
+        }
+    }
+
 } // namespace pluginkit
 } // namespace osvr
 

--- a/inc/osvr/PluginKit/PluginRegistrationC.h
+++ b/inc/osvr/PluginKit/PluginRegistrationC.h
@@ -35,6 +35,7 @@
 #include <osvr/PluginKit/CommonC.h>
 #include <osvr/Util/PluginCallbackTypesC.h>
 #include <osvr/Util/AnnotationMacrosC.h>
+#include <osvr/Util/LogLevelC.h>
 
 /* Library/third-party includes */
 #include <libfunctionality/PluginInterface.h>
@@ -142,6 +143,18 @@ OSVR_PLUGINKIT_EXPORT OSVR_ReturnCode osvrPluginRegisterDataWithDeleteCallback(
     OSVR_IN OSVR_PluginDataDeleteCallback deleteCallback,
     OSVR_INOUT_PTR void *pluginData) OSVR_FUNC_NONNULL((1, 2, 3));
 /** @} */
+
+/**
+ * @brief Log a message to the plugin's log channel.
+ *
+ * @param ctx The registration context passed to your entry point.
+ * @param severity The severity of the log message.
+ * @param message The message to be logged.
+ */
+OSVR_PLUGINKIT_EXPORT OSVR_ReturnCode
+    osvrPluginLog(OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
+                  OSVR_IN OSVR_LogLevel severity,
+                  OSVR_IN const char *message) OSVR_FUNC_NONNULL((1, 3));
 
 OSVR_EXTERN_C_END
 

--- a/inc/osvr/PluginKit/PluginRegistrationC.h
+++ b/inc/osvr/PluginKit/PluginRegistrationC.h
@@ -151,10 +151,10 @@ OSVR_PLUGINKIT_EXPORT OSVR_ReturnCode osvrPluginRegisterDataWithDeleteCallback(
  * @param severity The severity of the log message.
  * @param message The message to be logged.
  */
-OSVR_PLUGINKIT_EXPORT OSVR_ReturnCode
-    osvrPluginLog(OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
-                  OSVR_IN OSVR_LogLevel severity,
-                  OSVR_IN const char *message) OSVR_FUNC_NONNULL((1, 3));
+OSVR_PLUGINKIT_EXPORT void
+osvrPluginLog(OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
+              OSVR_IN OSVR_LogLevel severity, OSVR_IN const char *message)
+    OSVR_FUNC_NONNULL((1, 3));
 
 OSVR_EXTERN_C_END
 

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -26,8 +26,8 @@
 #define INCLUDED_ConfigureServerFromFile_h_GUID_9DA4C152_2AE4_4394_E19E_C0B7EA41804F
 
 // Internal Includes
-#include <osvr/Server/Server.h>
 #include <osvr/Server/ConfigureServer.h>
+#include <osvr/Server/Server.h>
 #include <osvr/Util/Log.h>
 #include <osvr/Util/LogNames.h>
 
@@ -35,9 +35,9 @@
 // - none
 
 // Standard includes
-#include <iostream>
-#include <fstream>
 #include <exception>
+#include <fstream>
+#include <iostream>
 
 namespace osvr {
 namespace server {
@@ -58,7 +58,7 @@ namespace server {
         if (!config.good()) {
             log->error() << "Could not open config file!";
             log->error() << "Searched in the current directory; file may be "
-                   "misspelled, missing, or in a different directory.";
+                            "misspelled, missing, or in a different directory.";
             return nullptr;
         }
 
@@ -70,7 +70,8 @@ namespace server {
         } catch (std::exception &e) {
             log->error()
                 << "Caught exception constructing server from JSON config "
-                   "file: " << e.what();
+                   "file: "
+                << e.what();
             return nullptr;
         }
 
@@ -92,7 +93,7 @@ namespace server {
                 log->warn() << "Failed to load the following plugins:";
                 for (auto const &pluginError : srvConfig.getFailedPlugins()) {
                     log->warn() << " - " << pluginError.first << "\t"
-                        << pluginError.second;
+                                << pluginError.second;
                 }
             }
         }
@@ -110,13 +111,15 @@ namespace server {
             if (!srvConfig.getFailedInstantiations().empty()) {
                 log->error() << "Errors:";
                 for (auto const &error : srvConfig.getFailedInstantiations()) {
-                    log->error() << " - " << error.first << "\t" << error.second;
+                    log->error() << " - " << error.first << "\t"
+                                 << error.second;
                 }
             }
         }
 
         if (srvConfig.processExternalDevices()) {
-            log->info() << "External devices found and parsed from config file.";
+            log->info()
+                << "External devices found and parsed from config file.";
         }
 
         if (srvConfig.processRoutes()) {
@@ -128,15 +131,18 @@ namespace server {
         }
 
         if (srvConfig.processDisplay()) {
-            log->info() << "Display descriptor found and parsed from config file.";
+            log->info()
+                << "Display descriptor found and parsed from config file.";
         } else {
-            log->info() << "Using OSVR HDK for display configuration. "
+            log->info()
+                << "Using OSVR HDK for display configuration. "
                    "Did not find an alternate valid 'display' object in config "
                    "file.";
         }
 
         if (srvConfig.processRenderManagerParameters()) {
-            log->info() << "RenderManager config found and parsed from the config file.";
+            log->info() << "RenderManager config found and parsed from the "
+                           "config file.";
         }
 
         log->info() << "Triggering automatic hardware detection...";
@@ -149,4 +155,3 @@ namespace server {
 } // namespace osvr
 
 #endif // INCLUDED_ConfigureServerFromFile_h_GUID_9DA4C152_2AE4_4394_E19E_C0B7EA41804F
-

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -29,6 +29,7 @@
 #include <osvr/Server/Server.h>
 #include <osvr/Server/ConfigureServer.h>
 #include <osvr/Util/Log.h>
+#include <osvr/Util/LogNames.h>
 
 // Library/third-party includes
 // - none
@@ -48,7 +49,8 @@ namespace server {
     /// of the main server app to make alternate server-acting apps simpler to
     /// develop.
     inline ServerPtr configureServerFromFile(std::string const &configName) {
-        auto log = ::osvr::util::log::make_logger("OSVR Server");
+        auto log =
+            ::osvr::util::log::make_logger(::osvr::util::log::OSVR_SERVER_LOG);
 
         ServerPtr ret;
         log->info() << "Using config file '" << configName << "'.";

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -28,6 +28,7 @@
 // Internal Includes
 #include <osvr/Server/Server.h>
 #include <osvr/Server/ConfigureServer.h>
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 // - none
@@ -39,24 +40,6 @@
 
 namespace osvr {
 namespace server {
-    namespace detail {
-        class StreamPrefixer {
-          public:
-            StreamPrefixer(const char *prefix, std::ostream &os)
-                : m_prefix(prefix), m_os(&os) {}
-            template <typename T> std::ostream &operator<<(T val) {
-                return (*m_os) << m_prefix << val;
-            }
-
-          private:
-            const char *m_prefix;
-            std::ostream *m_os;
-        };
-
-        static detail::StreamPrefixer out("[OSVR Server] ", std::cout);
-        static detail::StreamPrefixer err("[OSVR Server] ", std::cerr);
-    } // namespace detail
-
     inline const char *getDefaultConfigFilename() {
         return "osvr_server_config.json";
     }
@@ -65,115 +48,103 @@ namespace server {
     /// of the main server app to make alternate server-acting apps simpler to
     /// develop.
     inline ServerPtr configureServerFromFile(std::string const &configName) {
-        using detail::out;
-        using detail::err;
-        using std::endl;
+        auto log = ::osvr::util::log::make_logger("OSVR Server");
+
         ServerPtr ret;
-        out << "Using config file '" << configName << "'" << endl;
+        log->info() << "Using config file '" << configName << "'.";
         std::ifstream config(configName);
         if (!config.good()) {
-            err << "\n"
-                << "Could not open config file!" << endl;
-            err << "Searched in the current directory; file may be "
-                   "misspelled, missing, or in a different directory."
-                << endl;
+            log->error() << "Could not open config file!";
+            log->error() << "Searched in the current directory; file may be "
+                   "misspelled, missing, or in a different directory.";
             return nullptr;
         }
 
         osvr::server::ConfigureServer srvConfig;
-        out << "Constructing server as configured..." << endl;
+        log->info() << "Constructing server as configured...";
         try {
             srvConfig.loadConfig(config);
             ret = srvConfig.constructServer();
         } catch (std::exception &e) {
-            err << "Caught exception constructing server from JSON config "
-                   "file: "
-                << e.what() << endl;
+            log->error()
+                << "Caught exception constructing server from JSON config "
+                   "file: " << e.what();
             return nullptr;
         }
 
         {
-            out << "Loading auto-loadable plugins..." << endl;
+            log->info() << "Loading auto-loadable plugins...";
             srvConfig.loadAutoPlugins();
         }
 
         {
-            out << "Loading plugins..." << endl;
+            log->info() << "Loading plugins...";
             srvConfig.loadPlugins();
             if (!srvConfig.getSuccessfulPlugins().empty()) {
-                out << "Successfully loaded the following plugins:" << endl;
+                log->info() << "Successfully loaded the following plugins:";
                 for (auto const &plugin : srvConfig.getSuccessfulPlugins()) {
-                    out << " - " << plugin << endl;
+                    log->info() << " - " << plugin;
                 }
-                out << "\n";
             }
             if (!srvConfig.getFailedPlugins().empty()) {
-                out << "Failed to load the following plugins:" << endl;
+                log->warn() << "Failed to load the following plugins:";
                 for (auto const &pluginError : srvConfig.getFailedPlugins()) {
-                    out << " - " << pluginError.first << "\t"
-                        << pluginError.second << endl;
+                    log->warn() << " - " << pluginError.first << "\t"
+                        << pluginError.second;
                 }
-                out << "\n";
             }
-
-            out << "\n";
         }
 
         {
-            out << "Instantiating configured drivers..." << endl;
+            log->info() << "Instantiating configured drivers...";
             bool success = srvConfig.instantiateDrivers();
             if (!srvConfig.getSuccessfulInstantiations().empty()) {
-                out << "Successes:" << endl;
+                log->info() << "Successes:";
                 for (auto const &driver :
                      srvConfig.getSuccessfulInstantiations()) {
-                    out << " - " << driver << endl;
+                    log->info() << " - " << driver;
                 }
-                out << "\n";
             }
             if (!srvConfig.getFailedInstantiations().empty()) {
-                out << "Errors:" << endl;
+                log->error() << "Errors:";
                 for (auto const &error : srvConfig.getFailedInstantiations()) {
-                    out << " - " << error.first << "\t" << error.second << endl;
+                    log->error() << " - " << error.first << "\t" << error.second;
                 }
-                out << "\n";
             }
-            out << "\n";
         }
 
         if (srvConfig.processExternalDevices()) {
-            out << "External devices found and parsed from config file."
-                << endl;
+            log->info() << "External devices found and parsed from config file.";
         }
 
         if (srvConfig.processRoutes()) {
-            out << "Routes found and parsed from config file." << endl;
+            log->info() << "Routes found and parsed from config file.";
         }
 
         if (srvConfig.processAliases()) {
-            out << "Aliases found and parsed from config file." << endl;
+            log->info() << "Aliases found and parsed from config file.";
         }
 
         if (srvConfig.processDisplay()) {
-            out << "Display descriptor found and parsed from config file."
-                << endl;
+            log->info() << "Display descriptor found and parsed from config file.";
         } else {
-            out << "Using OSVR HDK for display configuration. "
+            log->info() << "Using OSVR HDK for display configuration. "
                    "Did not find an alternate valid 'display' object in config "
-                   "file."
-                << endl;
+                   "file.";
         }
 
         if (srvConfig.processRenderManagerParameters()) {
-            out << "RenderManager config found and parsed from the config file."
-                << endl;
+            log->info() << "RenderManager config found and parsed from the config file.";
         }
 
-        out << "Triggering automatic hardware detection..." << endl;
+        log->info() << "Triggering automatic hardware detection...";
         ret->triggerHardwareDetect();
 
         return ret;
     }
+
 } // namespace server
 } // namespace osvr
 
 #endif // INCLUDED_ConfigureServerFromFile_h_GUID_9DA4C152_2AE4_4394_E19E_C0B7EA41804F
+

--- a/inc/osvr/Util/GetEnvironmentVariable.h
+++ b/inc/osvr/Util/GetEnvironmentVariable.h
@@ -26,7 +26,7 @@
 #define INCLUDED_GetEnvironmentVariable_h_GUID_500031B7_31FB_45A1_B1E9_8E61905A4E0F
 
 // Internal Includes
-#include <osvr/Common/Export.h>
+#include <osvr/Util/Export.h>
 
 // Library/third-party includes
 #include <boost/optional.hpp>
@@ -35,13 +35,17 @@
 #include <string>
 
 namespace osvr {
-namespace common {
+namespace util {
+
     /// @brief Gets an environment variable's value. On systems that don't
     /// distinguish between having a variable defined and having it non-empty
     /// (like Windows), empty will imply not defined and thus an empty
     /// boost::optional return value.
-    OSVR_COMMON_EXPORT boost::optional<std::string>
+    OSVR_UTIL_EXPORT boost::optional<std::string>
     getEnvironmentVariable(std::string const &var);
-} // namespace common
+
+} // namespace util
 } // namespace osvr
+
 #endif // INCLUDED_GetEnvironmentVariable_h_GUID_500031B7_31FB_45A1_B1E9_8E61905A4E0F
+

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -1,0 +1,122 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LineLogger_h_GUID_743865A8_E989_4A87_82D9_9BBF3E4C199D
+#define INCLUDED_LineLogger_h_GUID_743865A8_E989_4A87_82D9_9BBF3E4C199D
+
+// Internal Includes
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/Export.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <memory>       // for std::unique_ptr
+#include <string>       // for std::string
+
+// Forward declaration
+namespace spdlog {
+namespace details {
+struct log_msg;
+class line_logger;
+} // end namespace details
+} // end namespace spdlog
+
+namespace osvr {
+namespace util {
+namespace log {
+
+// Forward declaration
+class Logger;
+
+namespace detail {
+
+    /**
+     * @brief A wrapper class for spdlog::details::line_logger.
+     */
+    class LineLogger {
+      public:
+        OSVR_UTIL_EXPORT LineLogger(spdlog::details::line_logger &&line_logger);
+
+        /**
+         * @brief Move-only.
+         */
+        //@{
+        OSVR_UTIL_EXPORT LineLogger(const LineLogger &other) = delete;
+        OSVR_UTIL_EXPORT LineLogger &operator=(const LineLogger &) = delete;
+        OSVR_UTIL_EXPORT LineLogger &operator=(LineLogger &&) = delete;
+        OSVR_UTIL_EXPORT LineLogger(LineLogger &&other);
+        //@}
+
+        /**
+         * @brief Log the message using the callback logger.
+         */
+        OSVR_UTIL_EXPORT ~LineLogger();
+
+        /**
+         * @brief Support for format string with variadic args.
+         */
+        OSVR_UTIL_EXPORT void write(const char *what);
+
+        template <typename... Args>
+        OSVR_UTIL_EXPORT void write(const char *fmt, Args &&... args);
+
+        /**
+         * @brief Support for operator<<
+         *
+         * \name Stream operators
+         */
+        //@{
+        OSVR_UTIL_EXPORT LineLogger &operator<<(const char *what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(const std::string &what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(int what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned int what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(long what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned long what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(long long what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned long long what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(double what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(long double what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(float what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(char what);
+
+        template <typename T> OSVR_UTIL_EXPORT LineLogger &operator<<(T &&what);
+        //@}
+
+        OSVR_UTIL_EXPORT void disable();
+        OSVR_UTIL_EXPORT bool is_enabled() const;
+
+      private:
+        std::unique_ptr<spdlog::details::line_logger> lineLogger_;
+    };
+
+} // end namespace detail
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#endif // INCLUDED_LineLogger_h_GUID_743865A8_E989_4A87_82D9_9BBF3E4C199D
+

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -37,14 +37,15 @@
 #include <memory>  // for std::unique_ptr
 #include <sstream> // for std::ostringstream
 #include <string>  // for std::string
+#include <utility> // for std::forward
 
 // Forward declaration
 namespace spdlog {
 namespace details {
     struct log_msg;
     class line_logger;
-} // end namespace details
-} // end namespace spdlog
+} // namespace details
+} // namespace spdlog
 
 namespace osvr {
 namespace util {
@@ -124,9 +125,11 @@ namespace util {
                 std::unique_ptr<spdlog::details::line_logger> lineLogger_;
             };
 
-        } // end namespace detail
-    }     // end namespace log
-} // end namespace util
-} // end namespace osvr
+        } // namespace detail
+
+    } // namespace log
+
+} // namespace util
+} // namespace osvr
 
 #endif // INCLUDED_LineLogger_h_GUID_743865A8_E989_4A87_82D9_9BBF3E4C199D

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -36,6 +36,7 @@
 // Standard includes
 #include <memory>       // for std::unique_ptr
 #include <string>       // for std::string
+#include <sstream>      // for std::ostringstream
 
 // Forward declaration
 namespace spdlog {
@@ -91,7 +92,7 @@ namespace detail {
          */
         //@{
         OSVR_UTIL_EXPORT LineLogger &operator<<(const char *what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(const std::string &what);
+        OSVR_UTIL_EXPORT LineLogger &operator<<(const std::string what);
         OSVR_UTIL_EXPORT LineLogger &operator<<(int what);
         OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned int what);
         OSVR_UTIL_EXPORT LineLogger &operator<<(long what);
@@ -103,7 +104,15 @@ namespace detail {
         OSVR_UTIL_EXPORT LineLogger &operator<<(float what);
         OSVR_UTIL_EXPORT LineLogger &operator<<(char what);
 
-        template <typename T> OSVR_UTIL_EXPORT LineLogger &operator<<(T &&what);
+        template <typename T>
+        OSVR_UTIL_EXPORT LineLogger &operator<<(T &&what)
+        {
+            std::ostringstream ss;
+            ss.operator<<(std::forward<T>(what));
+            this->operator<<(ss.str());
+            return *this;
+        }
+
         //@}
 
         OSVR_UTIL_EXPORT void disable();

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -105,7 +105,7 @@ namespace detail {
         OSVR_UTIL_EXPORT LineLogger &operator<<(char what);
 
         template <typename T>
-        OSVR_UTIL_EXPORT LineLogger &operator<<(T &&what)
+        LineLogger &operator<<(T &&what)
         {
             std::ostringstream ss;
             ss.operator<<(std::forward<T>(what));

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -27,105 +27,106 @@
 #define INCLUDED_LineLogger_h_GUID_743865A8_E989_4A87_82D9_9BBF3E4C199D
 
 // Internal Includes
-#include <osvr/Util/LogLevel.h>
 #include <osvr/Util/Export.h>
+#include <osvr/Util/LogLevel.h>
 
 // Library/third-party includes
 // - none
 
 // Standard includes
-#include <memory>       // for std::unique_ptr
-#include <string>       // for std::string
-#include <sstream>      // for std::ostringstream
+#include <memory>  // for std::unique_ptr
+#include <sstream> // for std::ostringstream
+#include <string>  // for std::string
 
 // Forward declaration
 namespace spdlog {
 namespace details {
-struct log_msg;
-class line_logger;
+    struct log_msg;
+    class line_logger;
 } // end namespace details
 } // end namespace spdlog
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
-// Forward declaration
-class Logger;
+        // Forward declaration
+        class Logger;
 
-namespace detail {
+        namespace detail {
 
-    /**
-     * @brief A wrapper class for spdlog::details::line_logger.
-     */
-    class LineLogger {
-      public:
-        OSVR_UTIL_EXPORT LineLogger(spdlog::details::line_logger &&line_logger);
+            /**
+             * @brief A wrapper class for spdlog::details::line_logger.
+             */
+            class LineLogger {
+              public:
+                OSVR_UTIL_EXPORT
+                LineLogger(spdlog::details::line_logger &&line_logger);
 
-        /**
-         * @brief Move-only.
-         */
-        //@{
-        OSVR_UTIL_EXPORT LineLogger(const LineLogger &other) = delete;
-        OSVR_UTIL_EXPORT LineLogger &operator=(const LineLogger &) = delete;
-        OSVR_UTIL_EXPORT LineLogger &operator=(LineLogger &&) = delete;
-        OSVR_UTIL_EXPORT LineLogger(LineLogger &&other);
-        //@}
+                /**
+                 * @brief Move-only.
+                 */
+                //@{
+                OSVR_UTIL_EXPORT LineLogger(const LineLogger &other) = delete;
+                OSVR_UTIL_EXPORT LineLogger &
+                operator=(const LineLogger &) = delete;
+                OSVR_UTIL_EXPORT LineLogger &operator=(LineLogger &&) = delete;
+                OSVR_UTIL_EXPORT LineLogger(LineLogger &&other);
+                //@}
 
-        /**
-         * @brief Log the message using the callback logger.
-         */
-        OSVR_UTIL_EXPORT ~LineLogger();
+                /**
+                 * @brief Log the message using the callback logger.
+                 */
+                OSVR_UTIL_EXPORT ~LineLogger();
 
-        /**
-         * @brief Support for format string with variadic args.
-         */
-        OSVR_UTIL_EXPORT void write(const char *what);
+                /**
+                 * @brief Support for format string with variadic args.
+                 */
+                OSVR_UTIL_EXPORT void write(const char *what);
 
-        template <typename... Args>
-        OSVR_UTIL_EXPORT void write(const char *fmt, Args &&... args);
+                template <typename... Args>
+                OSVR_UTIL_EXPORT void write(const char *fmt, Args &&... args);
 
-        /**
-         * @brief Support for operator<<
-         *
-         * \name Stream operators
-         */
-        //@{
-        OSVR_UTIL_EXPORT LineLogger &operator<<(const char *what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(const std::string what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(int what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned int what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(long what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned long what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(long long what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned long long what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(double what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(long double what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(float what);
-        OSVR_UTIL_EXPORT LineLogger &operator<<(char what);
+                /**
+                 * @brief Support for operator<<
+                 *
+                 * \name Stream operators
+                 */
+                //@{
+                OSVR_UTIL_EXPORT LineLogger &operator<<(const char *what);
+                OSVR_UTIL_EXPORT LineLogger &
+                operator<<(const std::string &what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(int what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned int what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(long what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(unsigned long what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(long long what);
+                OSVR_UTIL_EXPORT LineLogger &
+                operator<<(unsigned long long what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(double what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(long double what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(float what);
+                OSVR_UTIL_EXPORT LineLogger &operator<<(char what);
 
-        template <typename T>
-        LineLogger &operator<<(T &&what)
-        {
-            std::ostringstream ss;
-            ss.operator<<(std::forward<T>(what));
-            this->operator<<(ss.str());
-            return *this;
-        }
+                template <typename T> LineLogger &operator<<(T &&what) {
+                    std::ostringstream ss;
+                    ss.operator<<(std::forward<T>(what));
+                    this->operator<<(ss.str());
+                    return *this;
+                }
 
-        //@}
+                //@}
 
-        OSVR_UTIL_EXPORT void disable();
-        OSVR_UTIL_EXPORT bool is_enabled() const;
+                OSVR_UTIL_EXPORT void disable();
+                OSVR_UTIL_EXPORT bool is_enabled() const;
 
-      private:
-        std::unique_ptr<spdlog::details::line_logger> lineLogger_;
-    };
+              private:
+                std::unique_ptr<spdlog::details::line_logger> lineLogger_;
+            };
 
-} // end namespace detail
-} // end namespace log
+        } // end namespace detail
+    }     // end namespace log
 } // end namespace util
 } // end namespace osvr
 
 #endif // INCLUDED_LineLogger_h_GUID_743865A8_E989_4A87_82D9_9BBF3E4C199D
-

--- a/inc/osvr/Util/Log.h
+++ b/inc/osvr/Util/Log.h
@@ -1,0 +1,72 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_Log_h_GUID_B6053E2B_593D_4ECA_8C3B_2C55D0FE6A49
+#define INCLUDED_Log_h_GUID_B6053E2B_593D_4ECA_8C3B_2C55D0FE6A49
+
+// Internal Includes
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/LineLogger.h>
+#include <osvr/Util/Logger.h>
+#include <osvr/Util/Export.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <vector>
+#include <memory>
+#include <string>
+
+namespace osvr {
+namespace util {
+namespace log {
+
+    OSVR_UTIL_EXPORT LoggerPtr make_logger(const std::string &logger_name);
+
+    OSVR_UTIL_EXPORT std::string getLoggingDirectory(bool make_dir = false);
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#ifdef BUILD_DEV_VERBOSE
+#define OSVR_TRACE(...)                                                        \
+    ::osvr::util::log::make_logger("OSVR")->trace()                            \
+        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;
+#else
+#define OSVR_TRACE(...)
+#endif
+
+#ifdef BUILD_DEV_VERBOSE
+#define OSVR_DEBUG(...)                                                        \
+    ::osvr::util::log::make_logger("OSVR")->debug()                            \
+        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;
+#else
+#define OSVR_DEBUG(...)
+#endif
+
+#endif // INCLUDED_Log_h_GUID_B6053E2B_593D_4ECA_8C3B_2C55D0FE6A49
+

--- a/inc/osvr/Util/Log.h
+++ b/inc/osvr/Util/Log.h
@@ -27,28 +27,32 @@
 #define INCLUDED_Log_h_GUID_B6053E2B_593D_4ECA_8C3B_2C55D0FE6A49
 
 // Internal Includes
-#include <osvr/Util/LogLevel.h>
-#include <osvr/Util/LineLogger.h>
-#include <osvr/Util/Logger.h>
 #include <osvr/Util/Export.h>
+#include <osvr/Util/LineLogger.h>
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/Logger.h>
 
 // Library/third-party includes
 // - none
 
 // Standard includes
-#include <vector>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
-    OSVR_UTIL_EXPORT LoggerPtr make_logger(const std::string &logger_name);
+        OSVR_UTIL_EXPORT LoggerPtr make_logger(const std::string &logger_name);
 
-    OSVR_UTIL_EXPORT std::string getLoggingDirectory(bool make_dir = false);
+        /// @brief For implementations with a centralized logger registry, flush
+        /// all logger sinks.
+        OSVR_UTIL_EXPORT void flush();
 
-} // end namespace log
+        OSVR_UTIL_EXPORT std::string getLoggingDirectory(bool make_dir = false);
+
+    } // end namespace log
 } // end namespace util
 } // end namespace osvr
 
@@ -69,4 +73,3 @@ namespace log {
 #endif
 
 #endif // INCLUDED_Log_h_GUID_B6053E2B_593D_4ECA_8C3B_2C55D0FE6A49
-

--- a/inc/osvr/Util/Log.h
+++ b/inc/osvr/Util/Log.h
@@ -56,20 +56,4 @@ namespace util {
 } // end namespace util
 } // end namespace osvr
 
-#ifdef BUILD_DEV_VERBOSE
-#define OSVR_TRACE(...)                                                        \
-    ::osvr::util::log::make_logger("OSVR")->trace()                            \
-        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;
-#else
-#define OSVR_TRACE(...)
-#endif
-
-#ifdef BUILD_DEV_VERBOSE
-#define OSVR_DEBUG(...)                                                        \
-    ::osvr::util::log::make_logger("OSVR")->debug()                            \
-        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;
-#else
-#define OSVR_DEBUG(...)
-#endif
-
 #endif // INCLUDED_Log_h_GUID_B6053E2B_593D_4ECA_8C3B_2C55D0FE6A49

--- a/inc/osvr/Util/LogLevel.h
+++ b/inc/osvr/Util/LogLevel.h
@@ -1,0 +1,62 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogLevel_h_GUID_721FFB5D_B4A7_416A_B11E_982C1A21795B
+#define INCLUDED_LogLevel_h_GUID_721FFB5D_B4A7_416A_B11E_982C1A21795B
+
+// Internal Includes
+#include <osvr/Util/LogLevelC.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace util {
+namespace log {
+
+    /**
+     * @brief Log message severity levels.
+     */
+    enum class LogLevel {
+        trace    = OSVR_LOGLEVEL_TRACE,    //< function entry and exit, control flow.
+        debug    = OSVR_LOGLEVEL_DEBUG,    //< developer-facing messages.
+        info     = OSVR_LOGLEVEL_INFO,     //< user-facing messages.
+        notice   = OSVR_LOGLEVEL_NOTICE,   //< normal but significant condition.
+        warn     = OSVR_LOGLEVEL_WARN,     //< warning conditions.
+        err      = OSVR_LOGLEVEL_ERR,      //< error messages.
+        critical = OSVR_LOGLEVEL_CRITICAL, //< critical conditions.
+        alert    = OSVR_LOGLEVEL_ALERT,    //< action must be taken immediately.
+        emerg    = OSVR_LOGLEVEL_EMERG,    //< system is unusable.
+    };
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#endif // INCLUDED_LogLevel_h_GUID_721FFB5D_B4A7_416A_B11E_982C1A21795B
+

--- a/inc/osvr/Util/LogLevel.h
+++ b/inc/osvr/Util/LogLevel.h
@@ -37,26 +37,24 @@
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
-    /**
-     * @brief Log message severity levels.
-     */
-    enum class LogLevel {
-        trace    = OSVR_LOGLEVEL_TRACE,    //< function entry and exit, control flow.
-        debug    = OSVR_LOGLEVEL_DEBUG,    //< developer-facing messages.
-        info     = OSVR_LOGLEVEL_INFO,     //< user-facing messages.
-        notice   = OSVR_LOGLEVEL_NOTICE,   //< normal but significant condition.
-        warn     = OSVR_LOGLEVEL_WARN,     //< warning conditions.
-        err      = OSVR_LOGLEVEL_ERR,      //< error messages.
-        critical = OSVR_LOGLEVEL_CRITICAL, //< critical conditions.
-        alert    = OSVR_LOGLEVEL_ALERT,    //< action must be taken immediately.
-        emerg    = OSVR_LOGLEVEL_EMERG,    //< system is unusable.
-    };
+        /**
+         * @brief Log message severity levels.
+         */
+        enum class LogLevel {
+            trace =
+                OSVR_LOGLEVEL_TRACE, //< function entry and exit, control flow.
+            debug = OSVR_LOGLEVEL_DEBUG,   //< developer-facing messages.
+            info = OSVR_LOGLEVEL_INFO,     //< user-facing messages.
+            notice = OSVR_LOGLEVEL_NOTICE, //< normal but significant condition.
+            warn = OSVR_LOGLEVEL_WARN,     //< warning conditions.
+            err = OSVR_LOGLEVEL_ERR,       //< error messages.
+            critical = OSVR_LOGLEVEL_CRITICAL, //< critical conditions.
+        };
 
-} // end namespace log
-} // end namespace util
-} // end namespace osvr
+    } // namespace log
+} // namespace util
+} // namespace osvr
 
 #endif // INCLUDED_LogLevel_h_GUID_721FFB5D_B4A7_416A_B11E_982C1A21795B
-

--- a/inc/osvr/Util/LogLevel.h
+++ b/inc/osvr/Util/LogLevel.h
@@ -49,7 +49,7 @@ namespace util {
             info = OSVR_LOGLEVEL_INFO,     //< user-facing messages.
             notice = OSVR_LOGLEVEL_NOTICE, //< normal but significant condition.
             warn = OSVR_LOGLEVEL_WARN,     //< warning conditions.
-            err = OSVR_LOGLEVEL_ERR,       //< error messages.
+            error = OSVR_LOGLEVEL_ERROR,       //< error messages.
             critical = OSVR_LOGLEVEL_CRITICAL, //< critical conditions.
         };
 

--- a/inc/osvr/Util/LogLevelC.h
+++ b/inc/osvr/Util/LogLevelC.h
@@ -38,20 +38,18 @@
 // Standard includes
 // - none
 
-    /**
-     * @brief Log message severity levels.
-     */
-    typedef enum OSVR_LogLevel {
-        OSVR_LOGLEVEL_TRACE    = 0, //< function entry and exit, control flow.
-        OSVR_LOGLEVEL_DEBUG    = 1, //< debug-level messages.
-        OSVR_LOGLEVEL_INFO     = 2, //< informational messages.
-        OSVR_LOGLEVEL_NOTICE   = 3, //< normal but significant condition.
-        OSVR_LOGLEVEL_WARN     = 4, //< warning conditions.
-        OSVR_LOGLEVEL_ERR      = 5, //< error messages.
-        OSVR_LOGLEVEL_CRITICAL = 6, //< critical conditions.
-        OSVR_LOGLEVEL_ALERT    = 7, //< action must be taken immediately.
-        OSVR_LOGLEVEL_EMERG    = 8, //< system is unusable.
-    } OSVR_LogLevel;
+/**
+ * @brief Log message severity levels.
+ */
+typedef enum OSVR_LogLevel {
+    OSVR_LOGLEVEL_TRACE = 0,     //< function entry and exit, control flow.
+    OSVR_LOGLEVEL_DEBUG = 10,    //< debug-level messages.
+    OSVR_LOGLEVEL_INFO = 20,     //< informational messages.
+    OSVR_LOGLEVEL_NOTICE = 30,   //< normal but significant condition.
+    OSVR_LOGLEVEL_WARN = 40,     //< warning conditions.
+    OSVR_LOGLEVEL_ERR = 50,      //< error messages.
+    OSVR_LOGLEVEL_CRITICAL = 60, //< critical conditions.
+} OSVR_LogLevel;
 
 #endif // INCLUDED_LogLevelC_h_GUID_FF2DBB1E_A452_44B9_AE54_491C87D061D6
 

--- a/inc/osvr/Util/LogLevelC.h
+++ b/inc/osvr/Util/LogLevelC.h
@@ -47,7 +47,7 @@ typedef enum OSVR_LogLevel {
     OSVR_LOGLEVEL_INFO = 20,     //< informational messages.
     OSVR_LOGLEVEL_NOTICE = 30,   //< normal but significant condition.
     OSVR_LOGLEVEL_WARN = 40,     //< warning conditions.
-    OSVR_LOGLEVEL_ERR = 50,      //< error messages.
+    OSVR_LOGLEVEL_ERROR = 50,      //< error messages.
     OSVR_LOGLEVEL_CRITICAL = 60, //< critical conditions.
 } OSVR_LogLevel;
 

--- a/inc/osvr/Util/LogLevelC.h
+++ b/inc/osvr/Util/LogLevelC.h
@@ -1,0 +1,57 @@
+/** @file
+    @brief Header
+
+    Must be c-safe!
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogLevelC_h_GUID_FF2DBB1E_A452_44B9_AE54_491C87D061D6
+#define INCLUDED_LogLevelC_h_GUID_FF2DBB1E_A452_44B9_AE54_491C87D061D6
+
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+    /**
+     * @brief Log message severity levels.
+     */
+    typedef enum OSVR_LogLevel {
+        OSVR_LOGLEVEL_TRACE    = 0, //< function entry and exit, control flow.
+        OSVR_LOGLEVEL_DEBUG    = 1, //< debug-level messages.
+        OSVR_LOGLEVEL_INFO     = 2, //< informational messages.
+        OSVR_LOGLEVEL_NOTICE   = 3, //< normal but significant condition.
+        OSVR_LOGLEVEL_WARN     = 4, //< warning conditions.
+        OSVR_LOGLEVEL_ERR      = 5, //< error messages.
+        OSVR_LOGLEVEL_CRITICAL = 6, //< critical conditions.
+        OSVR_LOGLEVEL_ALERT    = 7, //< action must be taken immediately.
+        OSVR_LOGLEVEL_EMERG    = 8, //< system is unusable.
+    } OSVR_LogLevel;
+
+#endif // INCLUDED_LogLevelC_h_GUID_FF2DBB1E_A452_44B9_AE54_491C87D061D6
+

--- a/inc/osvr/Util/LogNames.h
+++ b/inc/osvr/Util/LogNames.h
@@ -1,0 +1,47 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogNames_h_GUID_A9468387_BB38_4C9D_EE44_7E98AEEA4115
+#define INCLUDED_LogNames_h_GUID_A9468387_BB38_4C9D_EE44_7E98AEEA4115
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace util {
+    namespace log {
+
+        static const auto OSVR_SERVER_LOG = "OSVR Server";
+
+    } // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#endif // INCLUDED_LogNames_h_GUID_A9468387_BB38_4C9D_EE44_7E98AEEA4115

--- a/inc/osvr/Util/LogNames.h
+++ b/inc/osvr/Util/LogNames.h
@@ -39,6 +39,8 @@ namespace util {
     namespace log {
 
         static const auto OSVR_SERVER_LOG = "OSVR Server";
+        static const auto OSVR_GENERAL_LOG_NAME = "OSVR";
+        static const auto OSVR_CLIENTKIT_LOG_NAME = "OSVR ClientKit";
 
     } // end namespace log
 } // end namespace util

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -33,60 +33,67 @@
 // - none
 
 // Standard includes
-#include <memory>           // for std::shared_ptr
-#include <string>           // for std::string
-#include <vector>           // for std::vector
+#include <memory> // for std::shared_ptr
+#include <string> // for std::string
+#include <vector> // for std::vector
 
 // Forward declarations
 namespace spdlog {
 
-    namespace sinks {
-        class sink;
-    } // namespace sinks
+namespace sinks {
+    class sink;
+    class filter_sink;
+} // namespace sinks
 
-    using sink_ptr = std::shared_ptr<spdlog::sinks::sink>;
+using sink_ptr = std::shared_ptr<spdlog::sinks::sink>;
 
 } // namespace spdlog
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
-    class Logger;
-    using LoggerPtr = std::shared_ptr<Logger>;
+        class Logger;
+        using LoggerPtr = std::shared_ptr<Logger>;
 
-    class LogRegistry {
-      public:
-        LogRegistry(LogRegistry const &) = delete;            // copy construct
-        LogRegistry(LogRegistry &&) = delete;                 // move construct
-        LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
-        LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
+        class LogRegistry {
+          public:
+            LogRegistry(LogRegistry const &) = delete; // copy construct
+            LogRegistry(LogRegistry &&) = delete;      // move construct
+            LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
+            LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
 
-        static LogRegistry &instance();
+            static LogRegistry &instance();
 
-        LoggerPtr getOrCreateLogger(const std::string &logger_name);
+            LoggerPtr getOrCreateLogger(const std::string &logger_name);
 
-        /**
-         * @brief Sets the output pattern on all registered loggers.
-         */
-        void setPattern(const std::string &pattern);
+            /**
+             * @brief Sets the output pattern on all registered loggers.
+             */
+            void setPattern(const std::string &pattern);
 
-        /**
-         * @brief Sets the minimum level of messages to be logged on all
-         * registered loggers.
-         */
-        void setLevel(LogLevel severity);
+            /**
+             * @brief Sets the minimum level of messages to be logged on all
+             * registered loggers.
+             */
+            void setLevel(LogLevel severity);
 
-      protected:
-        LogRegistry();
-        ~LogRegistry();
+            /**
+             * @brief Sets the minimum level of messages to be logged to the
+             * console.
+             */
+            void setConsoleLevel(LogLevel severity);
 
-        std::vector<spdlog::sink_ptr> sinks_;
-    };
+          protected:
+            LogRegistry();
+            ~LogRegistry();
 
-} // namespace log
+            std::vector<spdlog::sink_ptr> sinks_;
+            std::shared_ptr<spdlog::sinks::filter_sink> console_filter_;
+        };
+
+    } // namespace log
 } // namespace util
 } // namespace osvr
 
 #endif // INCLUDED_LogRegistry_h_GUID_09DDD840_389E_430C_8CBD_9AC4EE3F93FE
-

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -67,6 +67,9 @@ namespace util {
 
             LoggerPtr getOrCreateLogger(const std::string &logger_name);
 
+            /// @brief Flush all sinks manually.
+            void flush();
+
             /**
              * @brief Sets the output pattern on all registered loggers.
              */

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -91,8 +91,17 @@ namespace util {
             LogRegistry();
             ~LogRegistry();
 
+          private:
+            void setLevelImpl(LogLevel severity);
+            void setConsoleLevelImpl(LogLevel severity);
+            void createFileSink();
+            LogLevel minLevel_;
+            LogLevel consoleLevel_;
+
             std::vector<spdlog::sink_ptr> sinks_;
             std::shared_ptr<spdlog::sinks::filter_sink> console_filter_;
+            LoggerPtr consoleOnlyLog_;
+            LoggerPtr generalLog_;
         };
 
     } // namespace log

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -1,0 +1,84 @@
+/** @file
+    @brief Regstry to maintain instantiated loggers and global settings.
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogRegistry_h_GUID_09DDD840_389E_430C_8CBD_9AC4EE3F93FE
+#define INCLUDED_LogRegistry_h_GUID_09DDD840_389E_430C_8CBD_9AC4EE3F93FE
+
+// Internal Includes
+#include <osvr/Util/LogLevel.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <memory>           // for std::shared_ptr
+#include <string>           // for std::string
+#include <vector>           // for std::vector
+
+// Forward declarations
+namespace spdlog {
+
+    namespace sinks {
+        class sink;
+    } // namespace sinks
+
+    using sink_ptr = std::shared_ptr<spdlog::sinks::sink>;
+
+} // namespace spdlog
+
+namespace osvr {
+namespace util {
+namespace log {
+
+    class Logger;
+    using LoggerPtr = std::shared_ptr<Logger>;
+
+    class LogRegistry {
+      public:
+        LogRegistry(LogRegistry const &) = delete;            // copy construct
+        LogRegistry(LogRegistry &&) = delete;                 // move construct
+        LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
+        LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
+
+        static LogRegistry &instance();
+
+        LoggerPtr getOrCreateLogger(const std::string &logger_name);
+
+        void setPattern(const std::string &pattern);
+        void setLevel(LogLevel severity);
+
+      protected:
+        LogRegistry();
+        ~LogRegistry();
+
+        std::vector<spdlog::sink_ptr> sinks_;
+    };
+
+} // namespace log
+} // namespace util
+} // namespace osvr
+
+#endif // INCLUDED_LogRegistry_h_GUID_09DDD840_389E_430C_8CBD_9AC4EE3F93FE
+

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -66,7 +66,15 @@ namespace log {
 
         LoggerPtr getOrCreateLogger(const std::string &logger_name);
 
+        /**
+         * @brief Sets the output pattern on all registered loggers.
+         */
         void setPattern(const std::string &pattern);
+
+        /**
+         * @brief Sets the minimum level of messages to be logged on all
+         * registered loggers.
+         */
         void setLevel(LogLevel severity);
 
       protected:

--- a/inc/osvr/Util/LogSinks.h
+++ b/inc/osvr/Util/LogSinks.h
@@ -30,11 +30,11 @@
 // - none
 
 // Library/third-party includes
-// - none
+#include <spdlog/sinks/ostream_sink.h>
 
 // Standard includes
-#include <mutex>
 #include <iostream>
+#include <mutex>
 
 namespace spdlog {
 namespace sinks {
@@ -52,46 +52,44 @@ namespace details {
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
-    /**
-     * @brief A sink which sends its output to std::cout. This sink is a drop-in
-     * replacement for spdlog::stdout_sink and differs only in that this sink isn't
-     * a singleton.
-     */
-    template <typename Mutex>
-    class stdout_sink : public ::spdlog::sinks::ostream_sink<Mutex> {
-    public:
-        stdout_sink() : ::spdlog::sinks::ostream_sink<Mutex>(std::cout, true)
-        {
-            // do nothing
-        }
-    };
+        /**
+         * @brief A sink which sends its output to std::cout. This sink is a
+         * drop-in replacement for spdlog::stdout_sink and differs only in that
+         * this sink isn't a singleton.
+         */
+        template <typename Mutex>
+        class stdout_sink : public ::spdlog::sinks::ostream_sink<Mutex> {
+          public:
+            stdout_sink()
+                : ::spdlog::sinks::ostream_sink<Mutex>(std::cout, true) {
+                // do nothing
+            }
+        };
 
-    typedef stdout_sink<::spdlog::details::null_mutex> stdout_sink_st;
-    typedef stdout_sink<std::mutex> stdout_sink_mt;
+        typedef stdout_sink<::spdlog::details::null_mutex> stdout_sink_st;
+        typedef stdout_sink<std::mutex> stdout_sink_mt;
 
+        /**
+         * @brief A sink which sends its output to std::cerr. This sink is a
+         * drop-in replacement for spdlog::stderr_sink and differs only in that
+         * this sink isn't a singleton.
+         */
+        template <typename Mutex>
+        class stderr_sink : public ::spdlog::sinks::ostream_sink<Mutex> {
+          public:
+            stderr_sink()
+                : ::spdlog::sinks::ostream_sink<Mutex>(std::cerr, true) {
+                // do nothing
+            }
+        };
 
-    /**
-     * @brief A sink which sends its output to std::cerr. This sink is a drop-in
-     * replacement for spdlog::stderr_sink and differs only in that this sink isn't
-     * a singleton.
-     */
-    template <typename Mutex>
-    class stderr_sink : public ::spdlog::sinks::ostream_sink<Mutex> {
-    public:
-        stderr_sink() : ::spdlog::sinks::ostream_sink<Mutex>(std::cerr, true)
-        {
-            // do nothing
-        }
-    };
+        typedef stderr_sink<std::mutex> stderr_sink_mt;
+        typedef stderr_sink<::spdlog::details::null_mutex> stderr_sink_st;
 
-    typedef stderr_sink<std::mutex> stderr_sink_mt;
-    typedef stderr_sink<::spdlog::details::null_mutex> stderr_sink_st;
-
-} // end namespace log
+    } // end namespace log
 } // end namespace util
 } // end namespace osvr
 
 #endif // INCLUDED_LogSinks_h_GUID_C582966D_EA04_42D2_83FF_19483537D704
-

--- a/inc/osvr/Util/LogSinks.h
+++ b/inc/osvr/Util/LogSinks.h
@@ -1,0 +1,97 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogSinks_h_GUID_C582966D_EA04_42D2_83FF_19483537D704
+#define INCLUDED_LogSinks_h_GUID_C582966D_EA04_42D2_83FF_19483537D704
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <mutex>
+#include <iostream>
+
+namespace spdlog {
+namespace sinks {
+
+    template <typename Mutex> class ostream_sink;
+
+} // end namespace sinks
+
+namespace details {
+
+    struct null_mutex;
+
+} // end namespace details
+} // end namespace spdlog
+
+namespace osvr {
+namespace util {
+namespace log {
+
+    /**
+     * @brief A sink which sends its output to std::cout. This sink is a drop-in
+     * replacement for spdlog::stdout_sink and differs only in that this sink isn't
+     * a singleton.
+     */
+    template <typename Mutex>
+    class stdout_sink : public ::spdlog::sinks::ostream_sink<Mutex> {
+    public:
+        stdout_sink() : ::spdlog::sinks::ostream_sink<Mutex>(std::cout, true)
+        {
+            // do nothing
+        }
+    };
+
+    typedef stdout_sink<::spdlog::details::null_mutex> stdout_sink_st;
+    typedef stdout_sink<std::mutex> stdout_sink_mt;
+
+
+    /**
+     * @brief A sink which sends its output to std::cerr. This sink is a drop-in
+     * replacement for spdlog::stderr_sink and differs only in that this sink isn't
+     * a singleton.
+     */
+    template <typename Mutex>
+    class stderr_sink : public ::spdlog::sinks::ostream_sink<Mutex> {
+    public:
+        stderr_sink() : ::spdlog::sinks::ostream_sink<Mutex>(std::cerr, true)
+        {
+            // do nothing
+        }
+    };
+
+    typedef stderr_sink<std::mutex> stderr_sink_mt;
+    typedef stderr_sink<::spdlog::details::null_mutex> stderr_sink_st;
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#endif // INCLUDED_LogSinks_h_GUID_C582966D_EA04_42D2_83FF_19483537D704
+

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -1,0 +1,171 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_Logger_h_GUID_D8ADC0E7_A358_4FF2_960F_10F098A22F4E
+#define INCLUDED_Logger_h_GUID_D8ADC0E7_A358_4FF2_960F_10F098A22F4E
+
+// Internal Includes
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/LineLogger.h>
+#include <osvr/Util/Export.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <string>           // for std::string
+#include <memory>           // for std::shared_ptr
+#include <vector>           // for std::vector
+
+// Forward declarations
+
+namespace spdlog {
+class logger;
+} // end namespace spdlog
+
+namespace osvr {
+namespace util {
+namespace log {
+
+    /**
+     * @brief A wrapper around the spdlog::logger class.
+     */
+    class Logger {
+      public:
+        OSVR_UTIL_EXPORT Logger(const std::string &logger_name);
+        OSVR_UTIL_EXPORT Logger(spdlog::logger *logger);
+        OSVR_UTIL_EXPORT Logger(std::shared_ptr<spdlog::logger> logger);
+
+        OSVR_UTIL_EXPORT virtual ~Logger();
+        OSVR_UTIL_EXPORT Logger(const Logger &) = delete;
+        OSVR_UTIL_EXPORT Logger &operator=(const Logger &) = delete;
+
+        OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
+        OSVR_UTIL_EXPORT void setLogLevel(LogLevel);
+
+        // logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt,
+                                                  Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt,
+                                                  Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt,
+                                                 Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger notice(const char *fmt,
+                                                   Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger warn(const char *fmt,
+                                                 Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger error(const char *fmt,
+                                                  Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger critical(const char *fmt,
+                                                     Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger alert(const char *fmt,
+                                                  Args &&... args);
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger emerg(const char *fmt,
+                                                  Args &&... args);
+
+        OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger notice(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger warn(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger error(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger critical(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger alert(const char *fmt);
+        OSVR_UTIL_EXPORT detail::LineLogger emerg(const char *fmt);
+
+        // logger.info(msg) << ".." call style
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger trace(T &&msg);
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger debug(T &&msg);
+        template <typename T> OSVR_UTIL_EXPORT detail::LineLogger info(T &&msg);
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger notice(T &&msg);
+        template <typename T> OSVR_UTIL_EXPORT detail::LineLogger warn(T &&msg);
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger error(T &&msg);
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger critical(T &&msg);
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger alert(T &&msg);
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger emerg(T &&msg);
+
+        // logger.info() << ".." call  style
+        OSVR_UTIL_EXPORT detail::LineLogger trace();
+        OSVR_UTIL_EXPORT detail::LineLogger debug();
+        OSVR_UTIL_EXPORT detail::LineLogger info();
+        OSVR_UTIL_EXPORT detail::LineLogger notice();
+        OSVR_UTIL_EXPORT detail::LineLogger warn();
+        OSVR_UTIL_EXPORT detail::LineLogger error();
+        OSVR_UTIL_EXPORT detail::LineLogger critical();
+        OSVR_UTIL_EXPORT detail::LineLogger alert();
+        OSVR_UTIL_EXPORT detail::LineLogger emerg();
+
+        // Logger.log(log_level, cppformat_string, arg1, arg2, arg3, ...) call
+        // style
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level, const char *fmt,
+                                                Args &&... args);
+
+        // logger.log(log_level, msg) << ".." call style
+        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level,
+                                                const char *msg);
+
+        // logger.log(log_level, msg) << ".." call style
+        template <typename T>
+        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level, T &&msg);
+
+        // logger.log(log_level) << ".." call  style
+        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level);
+
+        // Create log message with the given level, no matter what is the actual
+        // logger's level
+        template <typename... Args>
+        OSVR_UTIL_EXPORT detail::LineLogger
+        force_log(LogLevel level, const char *fmt, Args &&... args);
+
+        OSVR_UTIL_EXPORT virtual void flush();
+
+      protected:
+        std::shared_ptr<spdlog::logger> logger_;
+    };
+
+    typedef std::shared_ptr<Logger> LoggerPtr;
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#endif // INCLUDED_Logger_h_GUID_D8ADC0E7_A358_4FF2_960F_10F098A22F4E

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -65,35 +65,58 @@ namespace log {
         OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
         OSVR_UTIL_EXPORT void setLogLevel(LogLevel);
 
-        // logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt,
-                                                  Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt,
-                                                  Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt,
-                                                 Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger notice(const char *fmt,
-                                                   Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger warn(const char *fmt,
-                                                 Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger error(const char *fmt,
-                                                  Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger critical(const char *fmt,
-                                                     Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger alert(const char *fmt,
-                                                  Args &&... args);
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger emerg(const char *fmt,
-                                                  Args &&... args);
+#if 0
+        // These functions are not yet implemented because they expose the
+        // underlying spdlog classes.
 
+        // Logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
+        template <typename... Args> detail::LineLogger Logger::trace(const char* fmt, Args&&... args)
+        {
+            return logger_->trace(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::debug(const char* fmt, Args&&... args)
+        {
+            return logger_->debug(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::info(const char* fmt, Args&&... args)
+        {
+            return logger_->info(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::notice(const char* fmt, Args&&... args)
+        {
+            return logger_->notice(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::warn(const char* fmt, Args&&... args)
+        {
+            return logger_->warn(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::error(const char* fmt, Args&&... args)
+        {
+            return logger_->error(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::critical(const char* fmt, Args&&... args)
+        {
+            return logger_->critical(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::alert(const char* fmt, Args&&... args)
+        {
+            return logger_->alert(fmt, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args> detail::LineLogger Logger::emerg(const char* fmt, Args&&... args)
+        {
+            return logger_->emerg(fmt, std::forward<Args>(args)...);
+        }
+#endif
+
+        // logger.info(msg) ".." call style
         OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt);
         OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt);
         OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt);
@@ -104,23 +127,56 @@ namespace log {
         OSVR_UTIL_EXPORT detail::LineLogger alert(const char *fmt);
         OSVR_UTIL_EXPORT detail::LineLogger emerg(const char *fmt);
 
+#if 0
+        // These functions are not yet implemented because they expose the
+        // underlying spdlog classes.
+
         // logger.info(msg) << ".." call style
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger trace(T &&msg);
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger debug(T &&msg);
-        template <typename T> OSVR_UTIL_EXPORT detail::LineLogger info(T &&msg);
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger notice(T &&msg);
-        template <typename T> OSVR_UTIL_EXPORT detail::LineLogger warn(T &&msg);
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger error(T &&msg);
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger critical(T &&msg);
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger alert(T &&msg);
-        template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger emerg(T &&msg);
+        template <typename T> detail::LineLogger trace(T&& msg)
+        {
+            return logger_->trace(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger debug(T&& msg)
+        {
+            return logger_->debug(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger info(T&& msg)
+        {
+            return logger_->info(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger notice(T&& msg)
+        {
+            return logger_->notice(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger warn(T&& msg)
+        {
+            return logger_->warn(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger error(T&& msg)
+        {
+            return logger_->error(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger critical(T&& msg)
+        {
+            return logger_->critical(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger alert(T&& msg)
+        {
+            return logger_->alert(std::forward<T>(msg));
+        }
+
+        template <typename T> detail::LineLogger emerg(T&& msg)
+        {
+            return logger_->emerg(std::forward<T>(msg));
+        }
+#endif
 
         // logger.info() << ".." call  style
         OSVR_UTIL_EXPORT detail::LineLogger trace();
@@ -137,7 +193,29 @@ namespace log {
         // style
         template <typename... Args>
         OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level, const char *fmt,
-                                                Args &&... args);
+                                                Args &&... args)
+        {
+            switch (level) {
+            case LogLevel::trace:
+                return trace(fmt, std::forward<Args>(args)...);
+            case LogLevel::debug:
+                return debug(fmt, std::forward<Args>(args)...);
+            case LogLevel::info:
+                return info(fmt, std::forward<Args>(args)...);
+            case LogLevel::notice:
+                return notice(fmt, std::forward<Args>(args)...);
+            case LogLevel::warn:
+                return warn(fmt, std::forward<Args>(args)...);
+            case LogLevel::err:
+                return error(fmt, std::forward<Args>(args)...);
+            case LogLevel::critical:
+                return critical(fmt, std::forward<Args>(args)...);
+            case LogLevel::alert:
+                return alert(fmt, std::forward<Args>(args)...);
+            case LogLevel::emerg:
+                return emerg(fmt, std::forward<Args>(args)...);
+            }
+        }
 
         // logger.log(log_level, msg) << ".." call style
         OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level,
@@ -145,16 +223,48 @@ namespace log {
 
         // logger.log(log_level, msg) << ".." call style
         template <typename T>
-        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level, T &&msg);
+        detail::LineLogger log(LogLevel level, T&& msg)
+        {
+            switch (level) {
+            case LogLevel::trace:
+                return trace(std::forward<T>(msg));
+            case LogLevel::debug:
+                return debug(std::forward<T>(msg));
+            case LogLevel::info:
+                return info(std::forward<T>(msg));
+            case LogLevel::notice:
+                return notice(std::forward<T>(msg));
+            case LogLevel::warn:
+                return warn(std::forward<T>(msg));
+            case LogLevel::err:
+                return error(std::forward<T>(msg));
+            case LogLevel::critical:
+                return critical(std::forward<T>(msg));
+            case LogLevel::alert:
+                return alert(std::forward<T>(msg));
+            case LogLevel::emerg:
+                return emerg(std::forward<T>(msg));
+            }
+
+            return info(std::forward<T>(msg));
+        }
 
         // logger.log(log_level) << ".." call  style
         OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level);
 
+#if 0
+        // These functions are not yet implemented because they expose the
+        // underlying spdlog classes.
+
         // Create log message with the given level, no matter what is the actual
         // logger's level
         template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger
-        force_log(LogLevel level, const char *fmt, Args &&... args);
+        detail::LineLogger force_log(LogLevel level, const char* fmt, Args&&... args)
+        {
+            auto lvl = static_cast<spdlog::level::level_enum>(level);
+            return logger_->force_log(lvl, fmt, std::forward<Args>(args)...);
+        }
+#endif
 
         OSVR_UTIL_EXPORT virtual void flush();
 

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -57,110 +57,42 @@ namespace util {
          */
         class Logger {
           public:
+            /// Factory function: retrieves from the spdlog registry by name.
             OSVR_UTIL_EXPORT static LoggerPtr
             getFromSpdlogByName(const std::string &logger_name);
 
+            /// Construct from an existing spdlog logger
             OSVR_UTIL_EXPORT Logger(std::shared_ptr<spdlog::logger> logger);
 
+            /// Non-copyable
             OSVR_UTIL_EXPORT Logger(const Logger &) = delete;
+
+            /// Non-copy-assignable
             OSVR_UTIL_EXPORT Logger &operator=(const Logger &) = delete;
 
+            /// Get the minimum level at which this logger will actually forward
+            /// messages on to the sinks.
             OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
+            /// Set the minimum level at which this logger will actually forward
+            /// messages on to the sinks.
             OSVR_UTIL_EXPORT void setLogLevel(LogLevel level);
 
+            /// Set the log level at which this logger will trigger a flush.
             OSVR_UTIL_EXPORT void flushOn(LogLevel level);
-#if 0
-        // These functions are not yet implemented because they expose the
-        // underlying spdlog classes.
 
-        // Logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
-        template <typename... Args> detail::LineLogger Logger::trace(const char* fmt, Args&&... args)
-        {
-            return logger_->trace(fmt, std::forward<Args>(args)...);
-        }
+            /// @name logger->info(msg) (with optional << "more message") call style
+			/// @{
+            OSVR_UTIL_EXPORT detail::LineLogger trace(const char *msg);
+            OSVR_UTIL_EXPORT detail::LineLogger debug(const char *msg);
+            OSVR_UTIL_EXPORT detail::LineLogger info(const char *msg);
+            OSVR_UTIL_EXPORT detail::LineLogger notice(const char *msg);
+            OSVR_UTIL_EXPORT detail::LineLogger warn(const char *msg);
+            OSVR_UTIL_EXPORT detail::LineLogger error(const char *msg);
+            OSVR_UTIL_EXPORT detail::LineLogger critical(const char *msg);
+			/// @}
 
-        template <typename... Args> detail::LineLogger Logger::debug(const char* fmt, Args&&... args)
-        {
-            return logger_->debug(fmt, std::forward<Args>(args)...);
-        }
-
-        template <typename... Args> detail::LineLogger Logger::info(const char* fmt, Args&&... args)
-        {
-            return logger_->info(fmt, std::forward<Args>(args)...);
-        }
-
-        template <typename... Args> detail::LineLogger Logger::notice(const char* fmt, Args&&... args)
-        {
-            return logger_->notice(fmt, std::forward<Args>(args)...);
-        }
-
-        template <typename... Args> detail::LineLogger Logger::warn(const char* fmt, Args&&... args)
-        {
-            return logger_->warn(fmt, std::forward<Args>(args)...);
-        }
-
-        template <typename... Args> detail::LineLogger Logger::error(const char* fmt, Args&&... args)
-        {
-            return logger_->error(fmt, std::forward<Args>(args)...);
-        }
-
-        template <typename... Args> detail::LineLogger Logger::critical(const char* fmt, Args&&... args)
-        {
-            return logger_->critical(fmt, std::forward<Args>(args)...);
-        }
-#endif
-
-            // logger.info(msg) ".." call style
-            OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt);
-            OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt);
-            OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt);
-            OSVR_UTIL_EXPORT detail::LineLogger notice(const char *fmt);
-            OSVR_UTIL_EXPORT detail::LineLogger warn(const char *fmt);
-            OSVR_UTIL_EXPORT detail::LineLogger error(const char *fmt);
-            OSVR_UTIL_EXPORT detail::LineLogger critical(const char *fmt);
-
-#if 0
-        // These functions are not yet implemented because they expose the
-        // underlying spdlog classes.
-
-        // logger.info(msg) << ".." call style
-        template <typename T> detail::LineLogger trace(T&& msg)
-        {
-            return logger_->trace(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger debug(T&& msg)
-        {
-            return logger_->debug(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger info(T&& msg)
-        {
-            return logger_->info(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger notice(T&& msg)
-        {
-            return logger_->notice(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger warn(T&& msg)
-        {
-            return logger_->warn(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger error(T&& msg)
-        {
-            return logger_->error(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger critical(T&& msg)
-        {
-            return logger_->critical(std::forward<T>(msg));
-        }
-#endif
-
-            // logger.info() << ".." call  style
+            /// @name logger->info() << "msg" call style
+			/// @{
             OSVR_UTIL_EXPORT detail::LineLogger trace();
             OSVR_UTIL_EXPORT detail::LineLogger debug();
             OSVR_UTIL_EXPORT detail::LineLogger info();
@@ -168,85 +100,14 @@ namespace util {
             OSVR_UTIL_EXPORT detail::LineLogger warn();
             OSVR_UTIL_EXPORT detail::LineLogger error();
             OSVR_UTIL_EXPORT detail::LineLogger critical();
+			/// @}
 
-#if 0
-        // These functions are not yet implemented because they expose the
-        // underlying spdlog classes.
-
-        // Logger.log(log_level, cppformat_string, arg1, arg2, arg3, ...) call
-        // style
-        template <typename... Args>
-        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level, const char *fmt,
-                                                Args &&... args)
-        {
-            switch (level) {
-            case LogLevel::trace:
-                return trace(fmt, std::forward<Args>(args)...);
-            case LogLevel::debug:
-                return debug(fmt, std::forward<Args>(args)...);
-            case LogLevel::info:
-                return info(fmt, std::forward<Args>(args)...);
-            case LogLevel::notice:
-                return notice(fmt, std::forward<Args>(args)...);
-            case LogLevel::warn:
-                return warn(fmt, std::forward<Args>(args)...);
-            case LogLevel::error:
-                return error(fmt, std::forward<Args>(args)...);
-            case LogLevel::critical:
-                return critical(fmt, std::forward<Args>(args)...);
-            }
-        }
-#endif
-
-            // logger.log(log_level, msg) << ".." call style
+            /// logger.log(log_level, msg) << ".." call style
             OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level,
                                                     const char *msg);
 
-#if 0
-        // These functions are not yet implemented because they expose the
-        // underlying spdlog classes.
-
-        // logger.log(log_level, msg) << ".." call style
-        template <typename T>
-        detail::LineLogger log(LogLevel level, T&& msg)
-        {
-            switch (level) {
-            case LogLevel::trace:
-                return trace(std::forward<T>(msg));
-            case LogLevel::debug:
-                return debug(std::forward<T>(msg));
-            case LogLevel::info:
-                return info(std::forward<T>(msg));
-            case LogLevel::notice:
-                return notice(std::forward<T>(msg));
-            case LogLevel::warn:
-                return warn(std::forward<T>(msg));
-            case LogLevel::error:
-                return error(std::forward<T>(msg));
-            case LogLevel::critical:
-                return critical(std::forward<T>(msg));
-            }
-
-            return info(std::forward<T>(msg));
-        }
-#endif
-
-            // logger.log(log_level) << ".." call  style
+            /// logger.log(log_level) << "msg" call  style
             OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level);
-
-#if 0
-        // These functions are not yet implemented because they expose the
-        // underlying spdlog classes.
-
-        // Create log message with the given level, no matter what is the actual
-        // logger's level
-        template <typename... Args>
-        detail::LineLogger force_log(LogLevel level, const char* fmt, Args&&... args)
-        {
-            auto lvl = static_cast<spdlog::level::level_enum>(level);
-            return logger_->force_log(lvl, fmt, std::forward<Args>(args)...);
-        }
-#endif
 
             OSVR_UTIL_EXPORT void flush();
 

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -189,6 +189,10 @@ namespace log {
         OSVR_UTIL_EXPORT detail::LineLogger alert();
         OSVR_UTIL_EXPORT detail::LineLogger emerg();
 
+#if 0
+        // These functions are not yet implemented because they expose the
+        // underlying spdlog classes.
+
         // Logger.log(log_level, cppformat_string, arg1, arg2, arg3, ...) call
         // style
         template <typename... Args>
@@ -216,10 +220,15 @@ namespace log {
                 return emerg(fmt, std::forward<Args>(args)...);
             }
         }
+#endif
 
         // logger.log(log_level, msg) << ".." call style
         OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level,
                                                 const char *msg);
+
+#if 0
+        // These functions are not yet implemented because they expose the
+        // underlying spdlog classes.
 
         // logger.log(log_level, msg) << ".." call style
         template <typename T>
@@ -248,6 +257,7 @@ namespace log {
 
             return info(std::forward<T>(msg));
         }
+#endif
 
         // logger.log(log_level) << ".." call  style
         OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level);

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -62,9 +62,9 @@ namespace log {
         OSVR_UTIL_EXPORT Logger &operator=(const Logger &) = delete;
 
         OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
-        OSVR_UTIL_EXPORT void setLogLevel(LogLevel);
+        OSVR_UTIL_EXPORT void setLogLevel(LogLevel level);
 
-        OSVR_UTIL_EXPORT void flush_on(LogLevel);
+        OSVR_UTIL_EXPORT void flushOn(LogLevel level);
 #if 0
         // These functions are not yet implemented because they expose the
         // underlying spdlog classes.

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -27,17 +27,17 @@
 #define INCLUDED_Logger_h_GUID_D8ADC0E7_A358_4FF2_960F_10F098A22F4E
 
 // Internal Includes
-#include <osvr/Util/LogLevel.h>
-#include <osvr/Util/LineLogger.h>
 #include <osvr/Util/Export.h>
+#include <osvr/Util/LineLogger.h>
+#include <osvr/Util/LogLevel.h>
 
 // Library/third-party includes
 // - none
 
 // Standard includes
-#include <string>           // for std::string
-#include <memory>           // for std::shared_ptr
-#include <vector>           // for std::vector
+#include <memory> // for std::shared_ptr
+#include <string> // for std::string
+#include <vector> // for std::vector
 
 // Forward declarations
 
@@ -47,24 +47,28 @@ class logger;
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
+        class Logger;
 
-    /**
-     * @brief A wrapper around the spdlog::logger class.
-     */
-    class Logger {
-      public:
-        OSVR_UTIL_EXPORT Logger(const std::string &logger_name);
-        OSVR_UTIL_EXPORT Logger(std::shared_ptr<spdlog::logger> logger);
+        typedef std::shared_ptr<Logger> LoggerPtr;
 
-        OSVR_UTIL_EXPORT virtual ~Logger();
-        OSVR_UTIL_EXPORT Logger(const Logger &) = delete;
-        OSVR_UTIL_EXPORT Logger &operator=(const Logger &) = delete;
+        /**
+         * @brief A wrapper around the spdlog::logger class.
+         */
+        class Logger {
+          public:
+            OSVR_UTIL_EXPORT static LoggerPtr
+            getFromSpdlogByName(const std::string &logger_name);
 
-        OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
-        OSVR_UTIL_EXPORT void setLogLevel(LogLevel level);
+            OSVR_UTIL_EXPORT Logger(std::shared_ptr<spdlog::logger> logger);
 
-        OSVR_UTIL_EXPORT void flushOn(LogLevel level);
+            OSVR_UTIL_EXPORT Logger(const Logger &) = delete;
+            OSVR_UTIL_EXPORT Logger &operator=(const Logger &) = delete;
+
+            OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
+            OSVR_UTIL_EXPORT void setLogLevel(LogLevel level);
+
+            OSVR_UTIL_EXPORT void flushOn(LogLevel level);
 #if 0
         // These functions are not yet implemented because they expose the
         // underlying spdlog classes.
@@ -104,28 +108,16 @@ namespace log {
         {
             return logger_->critical(fmt, std::forward<Args>(args)...);
         }
-
-        template <typename... Args> detail::LineLogger Logger::alert(const char* fmt, Args&&... args)
-        {
-            return logger_->alert(fmt, std::forward<Args>(args)...);
-        }
-
-        template <typename... Args> detail::LineLogger Logger::emerg(const char* fmt, Args&&... args)
-        {
-            return logger_->emerg(fmt, std::forward<Args>(args)...);
-        }
 #endif
 
-        // logger.info(msg) ".." call style
-        OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger notice(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger warn(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger error(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger critical(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger alert(const char *fmt);
-        OSVR_UTIL_EXPORT detail::LineLogger emerg(const char *fmt);
+            // logger.info(msg) ".." call style
+            OSVR_UTIL_EXPORT detail::LineLogger trace(const char *fmt);
+            OSVR_UTIL_EXPORT detail::LineLogger debug(const char *fmt);
+            OSVR_UTIL_EXPORT detail::LineLogger info(const char *fmt);
+            OSVR_UTIL_EXPORT detail::LineLogger notice(const char *fmt);
+            OSVR_UTIL_EXPORT detail::LineLogger warn(const char *fmt);
+            OSVR_UTIL_EXPORT detail::LineLogger error(const char *fmt);
+            OSVR_UTIL_EXPORT detail::LineLogger critical(const char *fmt);
 
 #if 0
         // These functions are not yet implemented because they expose the
@@ -166,28 +158,16 @@ namespace log {
         {
             return logger_->critical(std::forward<T>(msg));
         }
-
-        template <typename T> detail::LineLogger alert(T&& msg)
-        {
-            return logger_->alert(std::forward<T>(msg));
-        }
-
-        template <typename T> detail::LineLogger emerg(T&& msg)
-        {
-            return logger_->emerg(std::forward<T>(msg));
-        }
 #endif
 
-        // logger.info() << ".." call  style
-        OSVR_UTIL_EXPORT detail::LineLogger trace();
-        OSVR_UTIL_EXPORT detail::LineLogger debug();
-        OSVR_UTIL_EXPORT detail::LineLogger info();
-        OSVR_UTIL_EXPORT detail::LineLogger notice();
-        OSVR_UTIL_EXPORT detail::LineLogger warn();
-        OSVR_UTIL_EXPORT detail::LineLogger error();
-        OSVR_UTIL_EXPORT detail::LineLogger critical();
-        OSVR_UTIL_EXPORT detail::LineLogger alert();
-        OSVR_UTIL_EXPORT detail::LineLogger emerg();
+            // logger.info() << ".." call  style
+            OSVR_UTIL_EXPORT detail::LineLogger trace();
+            OSVR_UTIL_EXPORT detail::LineLogger debug();
+            OSVR_UTIL_EXPORT detail::LineLogger info();
+            OSVR_UTIL_EXPORT detail::LineLogger notice();
+            OSVR_UTIL_EXPORT detail::LineLogger warn();
+            OSVR_UTIL_EXPORT detail::LineLogger error();
+            OSVR_UTIL_EXPORT detail::LineLogger critical();
 
 #if 0
         // These functions are not yet implemented because they expose the
@@ -214,17 +194,13 @@ namespace log {
                 return error(fmt, std::forward<Args>(args)...);
             case LogLevel::critical:
                 return critical(fmt, std::forward<Args>(args)...);
-            case LogLevel::alert:
-                return alert(fmt, std::forward<Args>(args)...);
-            case LogLevel::emerg:
-                return emerg(fmt, std::forward<Args>(args)...);
             }
         }
 #endif
 
-        // logger.log(log_level, msg) << ".." call style
-        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level,
-                                                const char *msg);
+            // logger.log(log_level, msg) << ".." call style
+            OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level,
+                                                    const char *msg);
 
 #if 0
         // These functions are not yet implemented because they expose the
@@ -249,18 +225,14 @@ namespace log {
                 return error(std::forward<T>(msg));
             case LogLevel::critical:
                 return critical(std::forward<T>(msg));
-            case LogLevel::alert:
-                return alert(std::forward<T>(msg));
-            case LogLevel::emerg:
-                return emerg(std::forward<T>(msg));
             }
 
             return info(std::forward<T>(msg));
         }
 #endif
 
-        // logger.log(log_level) << ".." call  style
-        OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level);
+            // logger.log(log_level) << ".." call  style
+            OSVR_UTIL_EXPORT detail::LineLogger log(LogLevel level);
 
 #if 0
         // These functions are not yet implemented because they expose the
@@ -276,15 +248,13 @@ namespace log {
         }
 #endif
 
-        OSVR_UTIL_EXPORT virtual void flush();
+            OSVR_UTIL_EXPORT void flush();
 
-      protected:
-        std::shared_ptr<spdlog::logger> logger_;
-    };
+          private:
+            std::shared_ptr<spdlog::logger> logger_;
+        };
 
-    typedef std::shared_ptr<Logger> LoggerPtr;
-
-} // end namespace log
+    } // end namespace log
 } // end namespace util
 } // end namespace osvr
 

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -35,6 +35,7 @@
 // - none
 
 // Standard includes
+#include <initializer_list>
 #include <memory> // for std::shared_ptr
 #include <string> // for std::string
 #include <vector> // for std::vector
@@ -43,6 +44,12 @@
 
 namespace spdlog {
 class logger;
+namespace sinks {
+    class sink;
+} // namespace sinks
+
+using sink_ptr = std::shared_ptr<spdlog::sinks::sink>;
+using sinks_init_list = std::initializer_list<sink_ptr>;
 } // end namespace spdlog
 
 namespace osvr {
@@ -57,12 +64,26 @@ namespace util {
          */
         class Logger {
           public:
+#if 0
             /// Factory function: retrieves from the spdlog registry by name.
             OSVR_UTIL_EXPORT static LoggerPtr
             getFromSpdlogByName(const std::string &logger_name);
+#endif
 
             /// Construct from an existing spdlog logger
             OSVR_UTIL_EXPORT Logger(std::shared_ptr<spdlog::logger> logger);
+
+            /// Construct with a name and an existing, single spdlog sink. (Does
+            /// not use any logger registry.)
+            OSVR_UTIL_EXPORT static LoggerPtr
+            makeWithSink(std::string const &name, spdlog::sink_ptr sink);
+
+            /// Construct with a name and an initializer list of existing spdlog
+            /// sinks. (Does
+            /// not use any logger registry.)
+            OSVR_UTIL_EXPORT static LoggerPtr
+            makeWithSinks(std::string const &name,
+                          spdlog::sinks_init_list sinks);
 
             /// Non-copyable
             OSVR_UTIL_EXPORT Logger(const Logger &) = delete;

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -65,6 +65,7 @@ namespace log {
         OSVR_UTIL_EXPORT LogLevel getLogLevel() const;
         OSVR_UTIL_EXPORT void setLogLevel(LogLevel);
 
+        OSVR_UTIL_EXPORT void flush_on(LogLevel);
 #if 0
         // These functions are not yet implemented because they expose the
         // underlying spdlog classes.

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -190,7 +190,7 @@ namespace util {
                 return notice(fmt, std::forward<Args>(args)...);
             case LogLevel::warn:
                 return warn(fmt, std::forward<Args>(args)...);
-            case LogLevel::err:
+            case LogLevel::error:
                 return error(fmt, std::forward<Args>(args)...);
             case LogLevel::critical:
                 return critical(fmt, std::forward<Args>(args)...);
@@ -221,7 +221,7 @@ namespace util {
                 return notice(std::forward<T>(msg));
             case LogLevel::warn:
                 return warn(std::forward<T>(msg));
-            case LogLevel::err:
+            case LogLevel::error:
                 return error(std::forward<T>(msg));
             case LogLevel::critical:
                 return critical(std::forward<T>(msg));

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -55,7 +55,6 @@ namespace log {
     class Logger {
       public:
         OSVR_UTIL_EXPORT Logger(const std::string &logger_name);
-        OSVR_UTIL_EXPORT Logger(spdlog::logger *logger);
         OSVR_UTIL_EXPORT Logger(std::shared_ptr<spdlog::logger> logger);
 
         OSVR_UTIL_EXPORT virtual ~Logger();

--- a/plugins/videobasedtracker/VideoTrackerCalibrationUtility.cpp
+++ b/plugins/videobasedtracker/VideoTrackerCalibrationUtility.cpp
@@ -51,9 +51,25 @@
 using std::endl;
 using namespace osvr::vbtracker;
 
-static osvr::server::detail::StreamPrefixer
+namespace myDetail {
+  class StreamPrefixer {
+  public:
+    StreamPrefixer(const char *prefix, std::ostream &os)
+      : m_prefix(prefix), m_os(&os) {}
+    template <typename T> std::ostream &operator<<(T val) {
+      return (*m_os) << m_prefix << val;
+    }
+
+  private:
+    const char *m_prefix;
+    std::ostream *m_os;
+  };
+
+} // namespace myDetail
+
+static myDetail::StreamPrefixer
     out("[OSVR Video Tracker Calibration] ", std::cout);
-static osvr::server::detail::StreamPrefixer
+static myDetail::StreamPrefixer
     err("[OSVR Video Tracker Calibration] ", std::cerr);
 
 /// @brief OpenCV's simple highgui module refers to windows by their name, so we

--- a/src/osvr/AnalysisPluginKit/CMakeLists.txt
+++ b/src/osvr/AnalysisPluginKit/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(${LIBNAME_FULL}
     osvrUtilCpp
     osvrCommon
     osvrClient
+    spdlog
     vendored-vrpn)
 
 # Add library alias to allow use of the same osvr_add_plugin script within this

--- a/src/osvr/Client/CMakeLists.txt
+++ b/src/osvr/Client/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(${LIBNAME_FULL}
     osvrCommon
     JsonCpp::JsonCpp
     vendored-vrpn
+    spdlog
     eigen-headers)
 
 install(FILES

--- a/src/osvr/Client/ClientInterfaceObjectManager.cpp
+++ b/src/osvr/Client/ClientInterfaceObjectManager.cpp
@@ -26,6 +26,7 @@
 #include <osvr/Common/PathTree.h>
 #include <osvr/Client/ClientInterfaceObjectManager.h>
 #include <osvr/Client/RemoteHandlerFactory.h>
+#include <osvr/Common/ClientContext.h>
 #include <osvr/Common/PathTreeObserver.h>
 #include <osvr/Common/PathTreeOwner.h>
 #include <osvr/Common/ClientInterface.h>
@@ -84,7 +85,7 @@ namespace client {
         auto source = common::resolveTreeNode(m_pathTree, path);
         if (!source.is_initialized()) {
             if (verboseFailure) {
-                OSVR_DEV_VERBOSE("Could not resolve source for " << path);
+                logger()->info() << "Could not resolve source for " << path;
             }
             return false;
         }
@@ -93,7 +94,7 @@ namespace client {
             *source, m_interfaces.getInterfacesForPath(path), *m_ctx);
 
         if (handler) {
-            OSVR_DEV_VERBOSE("Successfully produced handler for " << path);
+            logger()->info() << "Successfully produced handler for " << path;
             // Store the new handler in the interface tree
             auto oldHandler = m_interfaces.replaceHandlerForPath(path, handler);
             BOOST_ASSERT_MSG(
@@ -102,7 +103,7 @@ namespace client {
             return true;
         }
 
-        OSVR_DEV_VERBOSE("Could not produce handler for " << path);
+        logger()->info() << "Could not produce handler for " << path;
         return false;
     }
 
@@ -126,9 +127,13 @@ namespace client {
                 failedPaths.insert(path);
             }
         });
-        OSVR_DEV_VERBOSE("Connected " << successfulPaths << " of "
-                                      << successfulPaths + failedPaths.size()
-                                      << " unconnected paths successfully");
+        logger()->info() << "Connected " << successfulPaths << " of "
+                         << successfulPaths + failedPaths.size()
+                         << " unconnected paths successfully";
+    }
+
+    util::log::LoggerPtr const &ClientInterfaceObjectManager::logger() const {
+        return m_ctx->logger();
     }
 } // namespace client
 } // namespace osvr

--- a/src/osvr/Client/PureClientContext.cpp
+++ b/src/osvr/Client/PureClientContext.cpp
@@ -108,10 +108,10 @@ namespace client {
             m_systemDevice->addComponent(common::SystemComponent::create());
         using DedupJsonFunction =
             common::DeduplicatingFunctionWrapper<Json::Value const &>;
+
         m_systemComponent->registerReplaceTreeHandler(
             DedupJsonFunction([&](Json::Value nodes) {
-
-                OSVR_DEV_VERBOSE("Got updated path tree, processing");
+                logger()->debug("Got updated path tree, processing");
                 // Replace localhost before we even convert the json to a tree.
                 // replace the @localhost with the correct host name
                 // in case we are a remote client, otherwise the connection
@@ -133,13 +133,13 @@ namespace client {
             std::this_thread::sleep_for(STARTUP_LOOP_SLEEP);
         }
         if (!m_gotConnection) {
-            OSVR_DEV_VERBOSE(
-                "Could not connect to OSVR server in the timeout period "
-                "allotted of "
+            logger()->notice()
+                << "Could not connect to OSVR server in the timeout period "
+                   "allotted of "
                 << std::chrono::duration_cast<std::chrono::milliseconds>(
                        STARTUP_CONNECT_TIMEOUT)
                        .count()
-                << "ms");
+                << "ms";
             return; // Bail early if we don't even have a connection
         }
 
@@ -150,14 +150,18 @@ namespace client {
             std::this_thread::sleep_for(STARTUP_LOOP_SLEEP);
         }
         auto timeToStartup = (clock::now() - begin);
-        OSVR_DEV_VERBOSE(
-            "Connection process took "
+
+        // this message is just "info" if we're all good, but "notice" if we
+        // aren't fully set up yet.
+        logger()->log(m_pathTreeOwner ? util::log::LogLevel::info
+                                      : util::log::LogLevel::notice)
+            << "Connection process took "
             << std::chrono::duration_cast<std::chrono::milliseconds>(
                    timeToStartup)
                    .count()
             << "ms: " << (m_gotConnection ? "have connection to server, "
                                           : "don't have connection to server, ")
-            << (m_pathTreeOwner ? "have path tree" : "don't have path tree"));
+            << (m_pathTreeOwner ? "have path tree" : "don't have path tree");
     }
 
     PureClientContext::~PureClientContext() {}
@@ -167,7 +171,7 @@ namespace client {
         m_vrpnConns.updateAll();
 
         if (!m_gotConnection && m_mainConn->connected()) {
-            OSVR_DEV_VERBOSE("Got connection to main OSVR server");
+            logger()->info("Got connection to main OSVR server");
             m_gotConnection = true;
         }
 

--- a/src/osvr/ClientKit/CMakeLists.txt
+++ b/src/osvr/ClientKit/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(${LIBNAME_FULL}
     osvrClient
     osvrUtilCpp
     osvrCommon
+    spdlog
     eigen-headers)
 
 if(ANDROID)

--- a/src/osvr/ClientKit/ContextC.cpp
+++ b/src/osvr/ClientKit/ContextC.cpp
@@ -26,9 +26,10 @@
 #include <osvr/ClientKit/ContextC.h>
 #include <osvr/Common/ClientContext.h>
 #include <osvr/Client/CreateContext.h>
-#include <osvr/Common/GetEnvironmentVariable.h>
 #include <osvr/Common/Tracing.h>
+#include <osvr/Util/GetEnvironmentVariable.h>
 #include <osvr/Util/Verbosity.h>
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 // - none
@@ -40,7 +41,7 @@ static const char HOST_ENV_VAR[] = "OSVR_HOST";
 
 OSVR_ClientContext osvrClientInit(const char applicationIdentifier[],
                                   uint32_t /*flags*/) {
-    auto host = osvr::common::getEnvironmentVariable(HOST_ENV_VAR);
+    auto host = osvr::util::getEnvironmentVariable(HOST_ENV_VAR);
     if (host.is_initialized()) {
         OSVR_DEV_VERBOSE("Connecting to non-default host " << *host);
         return ::osvr::client::createContext(applicationIdentifier,
@@ -69,3 +70,14 @@ OSVR_ReturnCode osvrClientShutdown(OSVR_ClientContext ctx) {
     osvr::common::deleteContext(ctx);
     return OSVR_RETURN_SUCCESS;
 }
+
+OSVR_ReturnCode osvrClientLog(OSVR_ClientContext ctx, OSVR_LogLevel severity,
+                              const char *message) {
+    if (!ctx) {
+        return OSVR_RETURN_FAILURE;
+    }
+    const auto s = static_cast<osvr::util::log::LogLevel>(severity);
+    ctx->log(s, message);
+    return OSVR_RETURN_SUCCESS;
+}
+

--- a/src/osvr/ClientKit/ContextC.cpp
+++ b/src/osvr/ClientKit/ContextC.cpp
@@ -35,7 +35,7 @@
 // - none
 
 // Standard includes
-// - none
+#include <iostream>
 
 static const char HOST_ENV_VAR[] = "OSVR_HOST";
 
@@ -71,13 +71,13 @@ OSVR_ReturnCode osvrClientShutdown(OSVR_ClientContext ctx) {
     return OSVR_RETURN_SUCCESS;
 }
 
-OSVR_ReturnCode osvrClientLog(OSVR_ClientContext ctx, OSVR_LogLevel severity,
-                              const char *message) {
+void osvrClientLog(OSVR_ClientContext ctx, OSVR_LogLevel severity,
+                   const char *message) {
     if (!ctx) {
-        return OSVR_RETURN_FAILURE;
+        std::cerr << "[OSVR] " << message << std::endl;
+        return;
     }
+
     const auto s = static_cast<osvr::util::log::LogLevel>(severity);
     ctx->log(s, message);
-    return OSVR_RETURN_SUCCESS;
 }
-

--- a/src/osvr/ClientKit/ContextC.cpp
+++ b/src/osvr/ClientKit/ContextC.cpp
@@ -23,13 +23,14 @@
 // limitations under the License.
 
 // Internal Includes
+#include <osvr/Client/CreateContext.h>
 #include <osvr/ClientKit/ContextC.h>
 #include <osvr/Common/ClientContext.h>
-#include <osvr/Client/CreateContext.h>
 #include <osvr/Common/Tracing.h>
 #include <osvr/Util/GetEnvironmentVariable.h>
-#include <osvr/Util/Verbosity.h>
 #include <osvr/Util/Log.h>
+#include <osvr/Util/LogNames.h>
+#include <osvr/Util/Verbosity.h>
 
 // Library/third-party includes
 // - none
@@ -39,23 +40,35 @@
 
 static const char HOST_ENV_VAR[] = "OSVR_HOST";
 
+static inline osvr::util::log::LoggerPtr make_clientkit_logger() {
+    namespace log = osvr::util::log;
+    return log::make_logger(log::OSVR_CLIENTKIT_LOG_NAME);
+}
+
 OSVR_ClientContext osvrClientInit(const char applicationIdentifier[],
                                   uint32_t /*flags*/) {
     auto host = osvr::util::getEnvironmentVariable(HOST_ENV_VAR);
     if (host.is_initialized()) {
-        OSVR_DEV_VERBOSE("Connecting to non-default host " << *host);
+
+        make_clientkit_logger()->notice() << "App " << applicationIdentifier
+                                          << ": Connecting to non-default host "
+                                          << *host;
         return ::osvr::client::createContext(applicationIdentifier,
                                              host->c_str());
     }
-    OSVR_DEV_VERBOSE("Connecting to default (local) host");
+    make_clientkit_logger()->debug("Connecting to default (local) host");
     return ::osvr::client::createContext(applicationIdentifier);
 }
+
 OSVR_ReturnCode osvrClientCheckStatus(OSVR_ClientContext ctx) {
     if (!ctx) {
+        make_clientkit_logger()->error(
+            "Can't check status of a null Client Context!");
         return OSVR_RETURN_FAILURE;
     }
     return ctx->getStatus() ? OSVR_RETURN_SUCCESS : OSVR_RETURN_FAILURE;
 }
+
 OSVR_ReturnCode osvrClientUpdate(OSVR_ClientContext ctx) {
     osvr::common::tracing::ClientUpdate region;
     ctx->update();
@@ -64,7 +77,7 @@ OSVR_ReturnCode osvrClientUpdate(OSVR_ClientContext ctx) {
 
 OSVR_ReturnCode osvrClientShutdown(OSVR_ClientContext ctx) {
     if (nullptr == ctx) {
-        OSVR_DEV_VERBOSE("Can't delete a null Client Context!");
+        make_clientkit_logger()->error("Can't delete a null Client Context!");
         return OSVR_RETURN_FAILURE;
     }
     osvr::common::deleteContext(ctx);
@@ -73,11 +86,12 @@ OSVR_ReturnCode osvrClientShutdown(OSVR_ClientContext ctx) {
 
 void osvrClientLog(OSVR_ClientContext ctx, OSVR_LogLevel severity,
                    const char *message) {
+    const auto s = static_cast<osvr::util::log::LogLevel>(severity);
     if (!ctx) {
-        std::cerr << "[OSVR] " << message << std::endl;
+        make_clientkit_logger()->log(s)
+            << "Message from app (no client context): " << message;
         return;
     }
 
-    const auto s = static_cast<osvr::util::log::LogLevel>(severity);
     ctx->log(s, message);
 }

--- a/src/osvr/ClientKit/ServerAutoStartC.cpp
+++ b/src/osvr/ClientKit/ServerAutoStartC.cpp
@@ -27,7 +27,7 @@
 #include <osvr/Util/ProcessUtils.h>
 #include <osvr/Util/PlatformConfig.h>
 #include <osvr/Client/LocateServer.h>
-#include <osvr/Common/GetEnvironmentVariable.h>
+#include <osvr/Util/GetEnvironmentVariable.h>
 #if defined(OSVR_ANDROID)
 #include <osvr/Server/ConfigureServerFromFile.h>
 #endif

--- a/src/osvr/Common/CMakeLists.txt
+++ b/src/osvr/Common/CMakeLists.txt
@@ -62,7 +62,6 @@ set(API
     "${HEADER_LOCATION}/Endianness.h"
     "${HEADER_LOCATION}/EyeTrackerComponent.h"
     "${HEADER_LOCATION}/GeneralizedTransform.h"
-    "${HEADER_LOCATION}/GetEnvironmentVariable.h"
     "${HEADER_LOCATION}/ImagingComponent.h"
     "${CMAKE_CURRENT_BINARY_DIR}/ImagingComponentConfig.h"
     "${HEADER_LOCATION}/IntegerByteSwap.h"
@@ -141,7 +140,6 @@ set(SOURCE
     DirectionComponent.cpp
     EyeTrackerComponent.cpp
     GeneralizedTransform.cpp
-    GetEnvironmentVariable.cpp
     GetJSONStringFromTree.h
     ImagingComponent.cpp
     IPCRingBuffer.cpp
@@ -203,6 +201,7 @@ target_link_libraries(${LIBNAME_FULL}
     PRIVATE
     JsonCpp::JsonCpp
     vendored-vrpn
+    spdlog
     eigen-headers
     osvr_cxx11_flags
     ${OSVR_CODECVT_LIBRARIES})

--- a/src/osvr/Common/ClientContext.cpp
+++ b/src/osvr/Common/ClientContext.cpp
@@ -55,6 +55,9 @@ OSVR_ClientContextObject::OSVR_ClientContextObject(
     : m_appId(appId), m_clientInterfaceFactory(interfaceFactory),
       m_deleter(del), m_logger(osvr::util::log::make_logger(m_appId)) {
     OSVR_DEV_VERBOSE("Client context initialized for " << m_appId);
+
+osvr::util::log::LoggerPtr const &OSVR_ClientContextObject::logger() const {
+    return m_logger;
 }
 
 OSVR_ClientContextObject::OSVR_ClientContextObject(const char appId[],

--- a/src/osvr/Common/ClientContext.cpp
+++ b/src/osvr/Common/ClientContext.cpp
@@ -23,10 +23,10 @@
 // limitations under the License.
 
 // Internal Includes
+#include "GetJSONStringFromTree.h"
 #include <osvr/Common/ClientContext.h>
 #include <osvr/Common/ClientInterface.h>
 #include <osvr/Util/Verbosity.h>
-#include "GetJSONStringFromTree.h"
 
 // Library/third-party includes
 #include <boost/assert.hpp>
@@ -48,13 +48,23 @@ namespace common {
 } // namespace common
 } // namespace osvr
 
+static const auto CLIENT_LOG_PREFIX = "Client: ";
+static const auto OSVR_LIBS_CLIENT_LOG_PREFIX = "OSVR (client: ";
+static const auto OSVR_LIBS_CLIENT_LOG_SUFFIX = ")";
+
 OSVR_ClientContextObject::OSVR_ClientContextObject(
     const char appId[],
     osvr::common::ClientInterfaceFactory const &interfaceFactory,
     osvr::common::ClientContextDeleter del)
     : m_appId(appId), m_clientInterfaceFactory(interfaceFactory),
-      m_deleter(del), m_logger(osvr::util::log::make_logger(m_appId)) {
-    OSVR_DEV_VERBOSE("Client context initialized for " << m_appId);
+      m_deleter(del),
+      m_logger(osvr::util::log::make_logger(
+          OSVR_LIBS_CLIENT_LOG_PREFIX + m_appId + OSVR_LIBS_CLIENT_LOG_SUFFIX)),
+      m_clientLogger(
+          osvr::util::log::make_logger(CLIENT_LOG_PREFIX + m_appId)) {
+    m_logger->info() << "OSVR client context initialized for " << m_appId;
+    m_logger->flush();
+}
 
 osvr::util::log::LoggerPtr const &OSVR_ClientContextObject::logger() const {
     return m_logger;
@@ -66,7 +76,8 @@ OSVR_ClientContextObject::OSVR_ClientContextObject(const char appId[],
           appId, osvr::common::getStandardClientInterfaceFactory(), del) {}
 
 OSVR_ClientContextObject::~OSVR_ClientContextObject() {
-    OSVR_DEV_VERBOSE("Client context shut down for " << m_appId);
+    m_logger->info() << "OSVR client context shut down for " << m_appId;
+    m_logger->flush();
 }
 
 std::string const &OSVR_ClientContextObject::getAppId() const {
@@ -151,7 +162,7 @@ bool OSVR_ClientContextObject::getStatus() const { return m_getStatus(); }
 
 void OSVR_ClientContextObject::log(osvr::util::log::LogLevel severity,
                                    const char *message) {
-    m_logger->log(severity, message);
+    m_clientLogger->log(severity, message);
 }
 
 bool OSVR_ClientContextObject::m_getStatus() const {

--- a/src/osvr/Common/ClientContext.cpp
+++ b/src/osvr/Common/ClientContext.cpp
@@ -49,8 +49,8 @@ namespace common {
 } // namespace osvr
 
 static const auto CLIENT_LOG_PREFIX = "Client: ";
-static const auto OSVR_LIBS_CLIENT_LOG_PREFIX = "OSVR (client: ";
-static const auto OSVR_LIBS_CLIENT_LOG_SUFFIX = ")";
+static const auto OSVR_LIBS_CLIENT_LOG_PREFIX = "OSVR: ";
+static const auto OSVR_LIBS_CLIENT_LOG_SUFFIX = "";
 
 OSVR_ClientContextObject::OSVR_ClientContextObject(
     const char appId[],

--- a/src/osvr/Common/ClientContext.cpp
+++ b/src/osvr/Common/ClientContext.cpp
@@ -53,7 +53,7 @@ OSVR_ClientContextObject::OSVR_ClientContextObject(
     osvr::common::ClientInterfaceFactory const &interfaceFactory,
     osvr::common::ClientContextDeleter del)
     : m_appId(appId), m_clientInterfaceFactory(interfaceFactory),
-      m_deleter(del) {
+      m_deleter(del), m_logger(osvr::util::log::make_logger(m_appId)) {
     OSVR_DEV_VERBOSE("Client context initialized for " << m_appId);
 }
 
@@ -145,6 +145,11 @@ ClientContextDeleter OSVR_ClientContextObject::getDeleter() const {
 }
 
 bool OSVR_ClientContextObject::getStatus() const { return m_getStatus(); }
+
+void OSVR_ClientContextObject::log(osvr::util::log::LogLevel severity,
+                                   const char *message) {
+    m_logger->log(severity, message);
+}
 
 bool OSVR_ClientContextObject::m_getStatus() const {
     // by default, assume we are started up.

--- a/src/osvr/Connection/CMakeLists.txt
+++ b/src/osvr/Connection/CMakeLists.txt
@@ -77,5 +77,6 @@ target_link_libraries(${LIBNAME_FULL}
     PRIVATE
     osvrUtilCpp
     osvrCommon
+    spdlog
     vendored-vrpn
     util-runloopmanager)

--- a/src/osvr/Connection/Connection.cpp
+++ b/src/osvr/Connection/Connection.cpp
@@ -30,6 +30,7 @@
 #include <osvr/Connection/MessageType.h>
 #include "VrpnBasedConnection.h"
 #include "GenericConnectionDevice.h"
+#include <osvr/Util/LogNames.h>
 #include <osvr/Util/Verbosity.h>
 
 // Library/third-party includes
@@ -129,11 +130,11 @@ namespace connection {
         BOOST_ASSERT_MSG(device, "Device must be non-null!");
         auto const &names = device->getNames();
         if (names.size() == 1) {
-            OSVR_DEV_VERBOSE("Added device: " << names.front());
+            m_log->alert() << "Added device: " << names.front();
         } else {
-            OSVR_DEV_VERBOSE("Added device with names:");
+            m_log->alert() << "Added device with names:";
             for (auto const &name : names) {
-                OSVR_DEV_VERBOSE(" - " << name);
+                m_log->alert() << " - " << name;
             }
         }
         m_devices.push_back(device);
@@ -161,7 +162,8 @@ namespace connection {
         }
     }
 
-    Connection::Connection() {}
+    Connection::Connection()
+        : m_log(util::log::make_logger(util::log::OSVR_SERVER_LOG)) {}
 
     Connection::~Connection() {}
 

--- a/src/osvr/Connection/Connection.cpp
+++ b/src/osvr/Connection/Connection.cpp
@@ -130,11 +130,11 @@ namespace connection {
         BOOST_ASSERT_MSG(device, "Device must be non-null!");
         auto const &names = device->getNames();
         if (names.size() == 1) {
-            m_log->alert() << "Added device: " << names.front();
+            m_log->notice() << "Added device: " << names.front();
         } else {
-            m_log->alert() << "Added device with names:";
+            m_log->notice() << "Added device with names:";
             for (auto const &name : names) {
-                m_log->alert() << " - " << name;
+                m_log->notice() << " - " << name;
             }
         }
         m_devices.push_back(device);

--- a/src/osvr/JointClientKit/CMakeLists.txt
+++ b/src/osvr/JointClientKit/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(${LIBNAME_FULL}
     osvrServer
     JsonCpp::JsonCpp
     vendored-vrpn
+    spdlog
     eigen-headers)
 
 ###

--- a/src/osvr/PluginHost/CMakeLists.txt
+++ b/src/osvr/PluginHost/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${LIBNAME_FULL}
     libfunctionality::functionality
     osvrUtilCpp
     PRIVATE
+    spdlog
     boost_filesystem)
 
 ###

--- a/src/osvr/PluginHost/PluginSpecificRegistrationContext.cpp
+++ b/src/osvr/PluginHost/PluginSpecificRegistrationContext.cpp
@@ -25,6 +25,7 @@
 // Internal Includes
 #include <osvr/PluginHost/PluginSpecificRegistrationContext.h>
 #include "PluginSpecificRegistrationContextImpl.h"
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 // - none
@@ -57,9 +58,15 @@ namespace pluginhost {
     const std::string &PluginSpecificRegistrationContext::getName() const {
         return m_name;
     }
+
     PluginSpecificRegistrationContext::PluginSpecificRegistrationContext(
         std::string const &name)
-        : m_name(name) {}
+        : m_name(name), m_logger(util::log::make_logger(name)) {}
+
+    void PluginSpecificRegistrationContext::log(util::log::LogLevel severity,
+                                                const char *message) {
+        m_logger->log(severity, message);
+    }
 
 } // namespace pluginhost
 } // namespace osvr

--- a/src/osvr/PluginHost/RegistrationContext.cpp
+++ b/src/osvr/PluginHost/RegistrationContext.cpp
@@ -49,7 +49,7 @@
 
 namespace osvr {
 namespace pluginhost {
-
+    static const auto PLUGIN_HOST_LOGGER_NAME = "PluginHost";
     namespace fs = boost::filesystem;
 
     struct RegistrationContext::Impl : private boost::noncopyable {
@@ -60,7 +60,8 @@ namespace pluginhost {
     };
 
     RegistrationContext::RegistrationContext()
-        : m_impl(new Impl), m_logger(util::log::make_logger("PluginHost")) {}
+        : m_impl(new Impl),
+          m_logger(util::log::make_logger(PLUGIN_HOST_LOGGER_NAME)) {}
 
     RegistrationContext::~RegistrationContext() {
         // Reset the plugins in reverse order.
@@ -80,7 +81,7 @@ namespace pluginhost {
                                         std::string const &name,
                                         OSVR_PluginRegContext ctx,
                                         bool shouldRethrow = false) {
-        auto log = util::log::make_logger("PluginHost");
+        auto log = util::log::make_logger(PLUGIN_HOST_LOGGER_NAME);
         log->debug() << "Trying to load a plugin with the name " << name;
         try {
             plugin = libfunc::loadPluginByName(name, ctx);

--- a/src/osvr/PluginHost/RegistrationContext.cpp
+++ b/src/osvr/PluginHost/RegistrationContext.cpp
@@ -117,19 +117,20 @@ namespace pluginhost {
             // was the plugin pre-loaded or statically linked? Try loading
             // it by name.
             success = tryLoadingPlugin(plugin, pluginName, ctx);
-            if(!success) {
-                throw std::runtime_error("Could not find plugin named " + pluginName);
+            if (!success) {
+                throw std::runtime_error("Could not find plugin named " +
+                                         pluginName);
             }
         }
 
-        if(!success) {
+        if (!success) {
             const auto pluginPathNameNoExt =
                 (fs::path(pluginPathName).parent_path() /
                  fs::path(pluginPathName).stem())
                     .generic_string();
 
             success = tryLoadingPlugin(plugin, pluginPathName, ctx) ||
-                           tryLoadingPlugin(plugin, pluginPathNameNoExt, ctx, true);
+                      tryLoadingPlugin(plugin, pluginPathNameNoExt, ctx, true);
             if (!success) {
                 throw std::runtime_error(
                     "Unusual error occurred trying to load plugin named " +
@@ -151,15 +152,15 @@ namespace pluginhost {
             const auto pluginBaseName =
                 fs::path(plugin).filename().stem().generic_string();
             if (boost::iends_with(pluginBaseName, OSVR_PLUGIN_IGNORE_SUFFIX)) {
-                m_logger->debug()
-                    << "Ignoring manual-load plugin: " << pluginBaseName;
+                m_logger->debug() << "Ignoring manual-load plugin: "
+                                  << pluginBaseName;
                 continue;
             }
 
             try {
                 loadPlugin(pluginBaseName);
-                m_logger->info()
-                    << "Successfully loaded plugin: " << pluginBaseName;
+                m_logger->info() << "Successfully loaded plugin: "
+                                 << pluginBaseName;
             } catch (const std::exception &e) {
                 m_logger->warn() << "Failed to load plugin " << pluginBaseName
                                  << ": " << e.what();

--- a/src/osvr/PluginHost/RegistrationContext.cpp
+++ b/src/osvr/PluginHost/RegistrationContext.cpp
@@ -33,6 +33,7 @@
 #include <osvr/PluginHost/PathConfig.h>
 #include "PluginSpecificRegistrationContextImpl.h"
 #include <osvr/Util/Verbosity.h>
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 #include <libfunctionality/LoadPlugin.h>
@@ -57,7 +58,9 @@ namespace pluginhost {
 
         const std::vector<std::string> pluginPaths;
     };
-    RegistrationContext::RegistrationContext() : m_impl(new Impl) {}
+
+    RegistrationContext::RegistrationContext()
+        : m_impl(new Impl), m_logger(util::log::make_logger("PluginHost")) {}
 
     RegistrationContext::~RegistrationContext() {
         // Reset the plugins in reverse order.
@@ -77,12 +80,13 @@ namespace pluginhost {
                                         std::string const &name,
                                         OSVR_PluginRegContext ctx,
                                         bool shouldRethrow = false) {
-        OSVR_DEV_VERBOSE("Trying to load a plugin with the name " << name);
+        auto log = util::log::make_logger("PluginHost");
+        log->debug() << "Trying to load a plugin with the name " << name;
         try {
             plugin = libfunc::loadPluginByName(name, ctx);
             return true;
         } catch (std::runtime_error const &e) {
-            OSVR_DEV_VERBOSE("Failed: " << e.what());
+            log->debug() << "Failed: " << e.what();
             if (shouldRethrow) {
                 throw;
             }
@@ -142,25 +146,25 @@ namespace pluginhost {
 
         // Load all of the non-.manualload plugins
         for (const auto &plugin : pluginPathNames) {
-            OSVR_DEV_VERBOSE("Examining plugin '" << plugin << "'...");
+            m_logger->debug() << "Examining plugin '" << plugin << "'...";
             const auto pluginBaseName =
                 fs::path(plugin).filename().stem().generic_string();
             if (boost::iends_with(pluginBaseName, OSVR_PLUGIN_IGNORE_SUFFIX)) {
-                OSVR_DEV_VERBOSE(
-                    "Ignoring manual-load plugin: " << pluginBaseName);
+                m_logger->debug()
+                    << "Ignoring manual-load plugin: " << pluginBaseName;
                 continue;
             }
 
             try {
                 loadPlugin(pluginBaseName);
-                OSVR_DEV_VERBOSE(
-                    "Successfully loaded plugin: " << pluginBaseName);
+                m_logger->info()
+                    << "Successfully loaded plugin: " << pluginBaseName;
             } catch (const std::exception &e) {
-                OSVR_DEV_VERBOSE("Failed to load plugin " << pluginBaseName
-                                                          << ": " << e.what());
+                m_logger->warn() << "Failed to load plugin " << pluginBaseName
+                                 << ": " << e.what();
             } catch (...) {
-                OSVR_DEV_VERBOSE("Failed to load plugin "
-                                 << pluginBaseName << ": Unknown error.");
+                m_logger->warn() << "Failed to load plugin " << pluginBaseName
+                                 << ": Unknown error.";
             }
         }
     }

--- a/src/osvr/PluginHost/RegistrationContext.cpp
+++ b/src/osvr/PluginHost/RegistrationContext.cpp
@@ -159,7 +159,7 @@ namespace pluginhost {
 
             try {
                 loadPlugin(pluginBaseName);
-                m_logger->info() << "Successfully loaded plugin: "
+                m_logger->debug() << "Successfully loaded plugin: "
                                  << pluginBaseName;
             } catch (const std::exception &e) {
                 m_logger->warn() << "Failed to load plugin " << pluginBaseName

--- a/src/osvr/PluginKit/CMakeLists.txt
+++ b/src/osvr/PluginKit/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${LIBNAME_FULL}
     osvrUtilCpp
     osvrCommon
     vendored-vrpn
+    spdlog
     boost_thread)
 
 # Add library alias to allow use of the same osvr_add_plugin script within this

--- a/src/osvr/PluginKit/PluginRegistrationC.cpp
+++ b/src/osvr/PluginKit/PluginRegistrationC.cpp
@@ -79,3 +79,14 @@ OSVR_ReturnCode osvrPluginRegisterDataWithDeleteCallback(
     context->registerDataWithDeleteCallback(deleteCallback, pluginData);
     return OSVR_RETURN_SUCCESS;
 }
+
+OSVR_ReturnCode osvrPluginLog(OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
+                              OSVR_IN OSVR_LogLevel severity,
+                              OSVR_IN const char *message) {
+    OSVR_PLUGIN_HANDLE_NULL_CONTEXT("osvrPluginLog", ctx);
+    osvr::pluginhost::PluginSpecificRegistrationContext *context =
+        static_cast<osvr::pluginhost::PluginSpecificRegistrationContext *>(ctx);
+    auto s = static_cast<osvr::util::log::LogLevel>(severity);
+    context->log(s, message);
+    return OSVR_RETURN_SUCCESS;
+}

--- a/src/osvr/PluginKit/PluginRegistrationC.cpp
+++ b/src/osvr/PluginKit/PluginRegistrationC.cpp
@@ -33,7 +33,7 @@
 // - none
 
 // Standard includes
-// - none
+#include <iostream>
 
 OSVR_ReturnCode osvrPluginRegisterHardwareDetectCallback(
     OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
@@ -80,13 +80,17 @@ OSVR_ReturnCode osvrPluginRegisterDataWithDeleteCallback(
     return OSVR_RETURN_SUCCESS;
 }
 
-OSVR_ReturnCode osvrPluginLog(OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
-                              OSVR_IN OSVR_LogLevel severity,
-                              OSVR_IN const char *message) {
-    OSVR_PLUGIN_HANDLE_NULL_CONTEXT("osvrPluginLog", ctx);
+void osvrPluginLog(OSVR_INOUT_PTR OSVR_PluginRegContext ctx,
+                   OSVR_IN OSVR_LogLevel severity,
+                   OSVR_IN const char *message) {
+    if (!ctx) {
+        std::cerr << "[OSVR] " << message << std::endl;
+        return;
+    }
+
     osvr::pluginhost::PluginSpecificRegistrationContext *context =
         static_cast<osvr::pluginhost::PluginSpecificRegistrationContext *>(ctx);
     auto s = static_cast<osvr::util::log::LogLevel>(severity);
     context->log(s, message);
-    return OSVR_RETURN_SUCCESS;
 }
+

--- a/src/osvr/Server/CMakeLists.txt
+++ b/src/osvr/Server/CMakeLists.txt
@@ -50,4 +50,5 @@ target_link_libraries(${LIBNAME_FULL}
     boost_filesystem
     vendored-vrpn
     JsonCpp::JsonCpp
+    spdlog
     util-runloopmanager)

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -39,6 +39,8 @@
 #include <osvr/Common/AliasProcessor.h>
 #include <osvr/Util/StringLiteralFileToString.h>
 #include <osvr/Common/Tracing.h>
+#include <osvr/Util/LogNames.h>
+#include <osvr/Util/Logger.h>
 #include <osvr/Util/PortFlags.h>
 
 #include "osvr/Server/display_json.h" /// Fallback display descriptor.
@@ -69,7 +71,8 @@ namespace server {
                            boost::optional<int> const &port)
         : m_conn(conn), m_ctx(make_shared<pluginhost::RegistrationContext>()),
           m_host(host.get_value_or("localhost")),
-          m_port(port.get_value_or(util::UseDefaultPort)) {
+          m_port(port.get_value_or(util::UseDefaultPort)),
+          m_log(util::log::make_logger(util::log::OSVR_SERVER_LOG)) {
         if (!m_conn) {
             throw std::logic_error(
                 "Can't pass a null ConnectionPtr into Server constructor!");
@@ -215,13 +218,13 @@ namespace server {
             f();
         }
         if (m_triggeredDetect) {
-            OSVR_DEV_VERBOSE("Performing hardware auto-detection.");
+            m_log->info() << "Performing hardware auto-detection.";
             common::tracing::markHardwareDetect();
             m_ctx->triggerHardwareDetect();
             m_triggeredDetect = false;
         }
         if (m_treeDirty) {
-            OSVR_DEV_VERBOSE("Path tree updated or connection detected");
+            m_log->debug() << "Path tree updated or connection detected";
             m_sendTree();
             m_treeDirty.reset();
         }
@@ -323,7 +326,8 @@ namespace server {
         BOOST_ASSERT_MSG(
             self->m_inServerThread(),
             "This callback should never happen outside the server thread!");
-        OSVR_DEV_VERBOSE("Got an updated route from a client.");
+
+        self->m_log->info() << "Got an updated route from a client.";
         self->m_addRoute(std::string(p.buffer, p.payload_len));
         return 0;
     }
@@ -358,9 +362,10 @@ namespace server {
         m_callControlled([&] { m_treeDirty += true; });
     }
     void ServerImpl::m_sendTree() {
-        OSVR_DEV_VERBOSE("Sending path tree to clients.");
+
         common::tracing::markPathTreeBroadcast();
         m_systemComponent->sendReplacementTree(m_tree);
+        m_log->info() << "Sent path tree to clients.";
     }
 
     void ServerImpl::setSleepTime(int microseconds) {
@@ -373,8 +378,8 @@ namespace server {
         for (auto const &dev : m_conn->getDevices()) {
             auto const &descriptor = dev->getDeviceDescriptor();
             if (descriptor.empty()) {
-                OSVR_DEV_VERBOSE("Developer Warning: No device descriptor for "
-                                 << dev->getName());
+                m_log->warn() << "Developer Warning: No device descriptor for "
+                              << dev->getName();
             } else {
                 m_treeDirty += common::processDeviceDescriptorForPathTree(
                     m_tree, dev->getName(), descriptor, m_port, m_host);
@@ -387,7 +392,9 @@ namespace server {
         /// Conditional ensures that we don't "idle" faster than we run: Make
         /// sure we're sleeping longer now than we will be once we exit idle.
         if (self->m_currentSleepTime > self->m_sleepTime) {
-            OSVR_DEV_VERBOSE("Got first client connection, exiting idle mode.");
+
+            self->m_log->debug(
+                "Got first client connection, exiting idle mode.");
             self->m_currentSleepTime = self->m_sleepTime;
         }
         return 0;
@@ -399,7 +406,7 @@ namespace server {
         /// Conditional ensures that we don't "idle" faster than we run: Make
         /// sure we're sleeping shorter now than we will be once we enter idle.
         if (self->m_currentSleepTime < IDLE_SLEEP_TIME) {
-            OSVR_DEV_VERBOSE(
+            self->m_log->debug(
                 "Dropped last client connection, entering idle mode.");
             self->m_currentSleepTime = IDLE_SLEEP_TIME;
         }

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -24,35 +24,35 @@
 
 // Internal Includes
 #include "ServerImpl.h"
-#include <osvr/Connection/Connection.h>
-#include <osvr/Connection/ConnectionDevice.h>
-#include <osvr/PluginHost/RegistrationContext.h>
-#include <osvr/Util/MessageKeys.h>
-#include <osvr/Connection/MessageType.h>
-#include <osvr/Util/Verbosity.h>
 #include "../Connection/VrpnConnectionKind.h" /// @todo warning - cross-library internal header!
-#include <osvr/Util/Microsleep.h>
-#include <osvr/Common/SystemComponent.h>
+#include <osvr/Common/AliasProcessor.h>
 #include <osvr/Common/CommonComponent.h>
 #include <osvr/Common/PathTreeFull.h>
 #include <osvr/Common/ProcessDeviceDescriptor.h>
-#include <osvr/Common/AliasProcessor.h>
-#include <osvr/Util/StringLiteralFileToString.h>
+#include <osvr/Common/SystemComponent.h>
 #include <osvr/Common/Tracing.h>
+#include <osvr/Connection/Connection.h>
+#include <osvr/Connection/ConnectionDevice.h>
+#include <osvr/Connection/MessageType.h>
+#include <osvr/PluginHost/RegistrationContext.h>
 #include <osvr/Util/LogNames.h>
 #include <osvr/Util/Logger.h>
+#include <osvr/Util/MessageKeys.h>
+#include <osvr/Util/Microsleep.h>
 #include <osvr/Util/PortFlags.h>
+#include <osvr/Util/StringLiteralFileToString.h>
+#include <osvr/Util/Verbosity.h>
 
 #include "osvr/Server/display_json.h" /// Fallback display descriptor.
 
 // Library/third-party includes
-#include <vrpn_ConnectionPtr.h>
 #include <boost/variant.hpp>
 #include <json/reader.h>
+#include <vrpn_ConnectionPtr.h>
 
 // Standard includes
-#include <stdexcept>
 #include <functional>
+#include <stdexcept>
 
 namespace osvr {
 namespace server {

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -275,7 +275,7 @@ namespace server {
     inline void ServerImpl::m_callControlled(Callable f) {
         boost::unique_lock<boost::mutex> lock(m_runControl);
         if (m_running && boost::this_thread::get_id() != m_thread.get_id()) {
-            boost::unique_lock<boost::mutex> lock(m_mainThreadMutex);
+            boost::unique_lock<boost::mutex> innerLock(m_mainThreadMutex);
             TemporaryThreadIDChanger changer(m_mainThreadId);
             f();
         } else {
@@ -287,7 +287,7 @@ namespace server {
     inline void ServerImpl::m_callControlled(Callable f) const {
         boost::unique_lock<boost::mutex> lock(m_runControl);
         if (m_running && boost::this_thread::get_id() != m_thread.get_id()) {
-            boost::unique_lock<boost::mutex> lock(m_mainThreadMutex);
+            boost::unique_lock<boost::mutex> innerLock(m_mainThreadMutex);
             TemporaryThreadIDChanger changer(m_mainThreadId);
             f();
         } else {

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -37,6 +37,7 @@
 #include <osvr/Common/CommonComponent_fwd.h>
 #include <osvr/Common/PathTree.h>
 #include <osvr/Util/Flag.h>
+#include <osvr/Util/Log.h>
 
 // Library/third-party includes
 #include <boost/noncopyable.hpp>
@@ -249,6 +250,9 @@ namespace server {
 
         /// The port we're listening on, if any.
         int m_port;
+
+        /// The logger.
+        util::log::LoggerPtr m_log;
     };
 
     /// @brief Class to temporarily (in RAII style) change a thread ID variable

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -26,26 +26,26 @@
 #define INCLUDED_ServerImpl_h_GUID_BA15589C_D1AD_4BBE_4F93_8AC87043A982
 
 // Internal Includes
-#include <osvr/Server/Server.h>
-#include <osvr/Connection/ConnectionPtr.h>
-#include <osvr/Util/SharedPtr.h>
-#include <osvr/PluginHost/RegistrationContext_fwd.h>
-#include <osvr/Connection/MessageTypePtr.h>
-#include <osvr/Connection/DeviceToken.h>
-#include <osvr/Common/CreateDevice.h>
-#include <osvr/Common/SystemComponent_fwd.h>
 #include <osvr/Common/CommonComponent_fwd.h>
+#include <osvr/Common/CreateDevice.h>
 #include <osvr/Common/PathTree.h>
+#include <osvr/Common/SystemComponent_fwd.h>
+#include <osvr/Connection/ConnectionPtr.h>
+#include <osvr/Connection/DeviceToken.h>
+#include <osvr/Connection/MessageTypePtr.h>
+#include <osvr/PluginHost/RegistrationContext_fwd.h>
+#include <osvr/Server/Server.h>
 #include <osvr/Util/Flag.h>
 #include <osvr/Util/Log.h>
+#include <osvr/Util/SharedPtr.h>
 
 // Library/third-party includes
 #include <boost/noncopyable.hpp>
-#include <util/RunLoopManagerBoost.h>
-#include <boost/thread.hpp>
-#include <vrpn_Connection.h>
-#include <json/value.h>
 #include <boost/optional.hpp>
+#include <boost/thread.hpp>
+#include <json/value.h>
+#include <util/RunLoopManagerBoost.h>
+#include <vrpn_Connection.h>
 
 // Standard includes
 #include <string>

--- a/src/osvr/Util/CMakeLists.txt
+++ b/src/osvr/Util/CMakeLists.txt
@@ -152,6 +152,7 @@ set(SOURCE
     TimeValueC.cpp
     LineLogger.cpp
     LogConfig.h.in
+    LogDefaults.h
     Log.cpp
     Logger.cpp
     LogLevelTranslate.h

--- a/src/osvr/Util/CMakeLists.txt
+++ b/src/osvr/Util/CMakeLists.txt
@@ -88,6 +88,7 @@ set(API
     "${HEADER_LOCATION}/Log.h"
     "${HEADER_LOCATION}/LogLevel.h"
     "${HEADER_LOCATION}/LogLevelC.h"
+    "${HEADER_LOCATION}/LogNames.h"
     "${HEADER_LOCATION}/LogRegistry.h"
     "${HEADER_LOCATION}/LogSinks.h"
     "${HEADER_LOCATION}/MatrixConventionsC.h"

--- a/src/osvr/Util/CMakeLists.txt
+++ b/src/osvr/Util/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_LOG_SINGLETON "Enable or disable the logging singleton." TRUE)
 if(BUILD_LOG_SINGLETON)
     set(OSVR_UTIL_LOG_SINGLETON TRUE)
 endif()
-configure_file(Log.cpp.in "${CMAKE_CURRENT_BINARY_DIR}/Log.cpp")
+configure_file(LogConfig.h.in "${CMAKE_CURRENT_BINARY_DIR}/LogConfig.h")
 
 ###
 # Platform Config Header (and other external and internal configured headers)
@@ -150,7 +150,8 @@ set(SOURCE
     GuardInterface.cpp
     TimeValueC.cpp
     LineLogger.cpp
-    Log.cpp.in
+    LogConfig.h.in
+    Log.cpp
     Logger.cpp
     LogRegistry.cpp
     MatrixConventionsC.cpp
@@ -160,7 +161,7 @@ set(SOURCE
     ClientCallbackTypesC.h.in
     ClientCallbackTypesCSnippet.h.in
     WideToUTF8.h.in
-    "${CMAKE_CURRENT_BINARY_DIR}/Log.cpp"
+    "${CMAKE_CURRENT_BINARY_DIR}/LogConfig.h"
     "${CMAKE_CURRENT_BINARY_DIR}/ClientCallbackTypesC.h"
     "${CMAKE_CURRENT_BINARY_DIR}/StdAlignWrapper.h"
     "${CMAKE_CURRENT_BINARY_DIR}/Verbosity.h"

--- a/src/osvr/Util/CMakeLists.txt
+++ b/src/osvr/Util/CMakeLists.txt
@@ -6,6 +6,15 @@ if(BUILD_DEV_VERBOSE)
 endif()
 configure_file(Verbosity.h.in "${CMAKE_CURRENT_BINARY_DIR}/Verbosity.h")
 
+###
+# The logger singleton may be disabled if necessary.
+# It may result in degraded performance or disabled logging.
+###
+option(BUILD_LOG_SINGLETON "Enable or disable the logging singleton." TRUE)
+if(BUILD_LOG_SINGLETON)
+    set(OSVR_UTIL_LOG_SINGLETON TRUE)
+endif()
+configure_file(Log.cpp.in "${CMAKE_CURRENT_BINARY_DIR}/Log.cpp")
 
 ###
 # Platform Config Header (and other external and internal configured headers)
@@ -67,12 +76,20 @@ set(API
     "${HEADER_LOCATION}/Flag.h"
     "${HEADER_LOCATION}/GenericCaller.h"
     "${HEADER_LOCATION}/GenericDeleter.h"
+    "${HEADER_LOCATION}/GetEnvironmentVariable.h"
     "${HEADER_LOCATION}/GuardInterface.h"
     "${HEADER_LOCATION}/GuardInterfaceDummy.h"
     "${HEADER_LOCATION}/GuardPtr.h"
     "${HEADER_LOCATION}/ImagingReportTypesC.h"
     "${HEADER_LOCATION}/IndentingStream.h"
     "${HEADER_LOCATION}/KeyedOwnershipContainer.h"
+    "${HEADER_LOCATION}/LineLogger.h"
+    "${HEADER_LOCATION}/Logger.h"
+    "${HEADER_LOCATION}/Log.h"
+    "${HEADER_LOCATION}/LogLevel.h"
+    "${HEADER_LOCATION}/LogLevelC.h"
+    "${HEADER_LOCATION}/LogRegistry.h"
+    "${HEADER_LOCATION}/LogSinks.h"
     "${HEADER_LOCATION}/MatrixConventionsC.h"
     "${HEADER_LOCATION}/MatrixConventions.h"
     "${HEADER_LOCATION}/MatrixEigenAssign.h"
@@ -129,8 +146,13 @@ set(SOURCE
     AlignedMemoryC.cpp
     AnyMap.cpp
     Deletable.cpp
+    GetEnvironmentVariable.cpp
     GuardInterface.cpp
     TimeValueC.cpp
+    LineLogger.cpp
+    Log.cpp.in
+    Logger.cpp
+    LogRegistry.cpp
     MatrixConventionsC.cpp
     MessageKeys.cpp
     PlatformConfig.h.in
@@ -138,6 +160,7 @@ set(SOURCE
     ClientCallbackTypesC.h.in
     ClientCallbackTypesCSnippet.h.in
     WideToUTF8.h.in
+    "${CMAKE_CURRENT_BINARY_DIR}/Log.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/ClientCallbackTypesC.h"
     "${CMAKE_CURRENT_BINARY_DIR}/StdAlignWrapper.h"
     "${CMAKE_CURRENT_BINARY_DIR}/Verbosity.h"
@@ -167,6 +190,8 @@ target_link_libraries(${LIBNAME_FULL}
     PRIVATE
     vendored-vrpn
     eigen-headers
+    spdlog
+    boost_filesystem
     osvrTypePack)
 
 if(NOT OSVR_HAVE_STDALIGN)

--- a/src/osvr/Util/CMakeLists.txt
+++ b/src/osvr/Util/CMakeLists.txt
@@ -154,6 +154,7 @@ set(SOURCE
     LogConfig.h.in
     Log.cpp
     Logger.cpp
+    LogLevelTranslate.h
     LogRegistry.cpp
     MatrixConventionsC.cpp
     MessageKeys.cpp

--- a/src/osvr/Util/GetEnvironmentVariable.cpp
+++ b/src/osvr/Util/GetEnvironmentVariable.cpp
@@ -28,7 +28,7 @@
 #endif
 
 // Internal Includes
-#include <osvr/Common/GetEnvironmentVariable.h>
+#include <osvr/Util/GetEnvironmentVariable.h>
 #include <osvr/Util/WindowsVariantC.h>
 
 // Library/third-party includes
@@ -38,7 +38,7 @@
 #include <cstdlib>
 
 namespace osvr {
-namespace common {
+namespace util {
 #if defined(OSVR_WINDOWS) && !defined(OSVR_WINDOWS_DESKTOP)
     /// On Windows, only desktop apps actually have the getenv function
     /// available to them, so this implementation just always returns not
@@ -68,5 +68,5 @@ namespace common {
         return ret;
     }
 #endif // end of if windows non-desktop
-} // namespace common
+} // namespace util
 } // namespace osvr

--- a/src/osvr/Util/LineLogger.cpp
+++ b/src/osvr/Util/LineLogger.cpp
@@ -30,120 +30,104 @@
 #include <spdlog/spdlog.h>
 
 // Standard includes
-#include <algorithm>        // for std::move
-#include <utility>          // for std::forward
-#include <string>           // for std::string
+#include <algorithm> // for std::move
+#include <string>    // for std::string
+#include <utility>   // for std::forward
 
 namespace osvr {
 namespace util {
-namespace log {
-namespace detail {
+    namespace log {
+        namespace detail {
 
-LineLogger::LineLogger(spdlog::details::line_logger&& line_logger) : lineLogger_(new ::spdlog::details::line_logger(std::move(line_logger)))
-{
-    // do nothing
-}
+            LineLogger::LineLogger(spdlog::details::line_logger &&line_logger)
+                : lineLogger_(new ::spdlog::details::line_logger(
+                      std::move(line_logger))) {
+                // do nothing
+            }
 
-LineLogger::~LineLogger()
-{
-    // TODO
-}
+            LineLogger::LineLogger(LineLogger &&other)
+                : lineLogger_(std::move(other.lineLogger_)) {}
 
-void LineLogger::write(const char* what)
-{
-    lineLogger_->write(what);
-}
+            LineLogger::~LineLogger() {
+                // TODO
+            }
 
-template <typename... Args>
-void LineLogger::write(const char* fmt, Args&&... args)
-{
-    lineLogger_->write(fmt, std::forward<Args>(args)...);
-}
+            void LineLogger::write(const char *what) {
+                lineLogger_->write(what);
+            }
 
-LineLogger& LineLogger::operator<<(const char* what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            template <typename... Args>
+            void LineLogger::write(const char *fmt, Args &&... args) {
+                lineLogger_->write(fmt, std::forward<Args>(args)...);
+            }
 
-LineLogger& LineLogger::operator<<(const std::string what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(const char *what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(int what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(const std::string &what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(unsigned int what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(int what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(long what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(unsigned int what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(unsigned long what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(long what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(long long what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(unsigned long what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(unsigned long long what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(long long what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(double what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(unsigned long long what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(long double what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(double what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(float what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(long double what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-LineLogger& LineLogger::operator<<(char what)
-{
-    lineLogger_->operator<<(what);
-    return *this;
-}
+            LineLogger &LineLogger::operator<<(float what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-void LineLogger::disable()
-{
-    lineLogger_->disable();
-}
+            LineLogger &LineLogger::operator<<(char what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
 
-bool LineLogger::is_enabled() const
-{
-    return lineLogger_->is_enabled();
-}
+            void LineLogger::disable() { lineLogger_->disable(); }
 
-} // end namespace detail
-} // end namespace log
+            bool LineLogger::is_enabled() const {
+                return lineLogger_->is_enabled();
+            }
+
+        } // end namespace detail
+    }     // end namespace log
 } // end namespace util
 } // end namespace osvr
-

--- a/src/osvr/Util/LineLogger.cpp
+++ b/src/osvr/Util/LineLogger.cpp
@@ -60,7 +60,7 @@ namespace util {
             void LineLogger::write(const char *fmt, Args &&... args) {
                 lineLogger_->write(fmt, std::forward<Args>(args)...);
             }
-
+#if 0
             LineLogger &LineLogger::operator<<(const char *what) {
                 lineLogger_->operator<<(what);
                 return *this;
@@ -70,7 +70,6 @@ namespace util {
                 lineLogger_->operator<<(what);
                 return *this;
             }
-
             LineLogger &LineLogger::operator<<(int what) {
                 lineLogger_->operator<<(what);
                 return *this;
@@ -117,6 +116,12 @@ namespace util {
             }
 
             LineLogger &LineLogger::operator<<(char what) {
+                lineLogger_->operator<<(what);
+                return *this;
+            }
+
+#endif
+            LineLogger &LineLogger::append(const std::string &what) {
                 lineLogger_->operator<<(what);
                 return *this;
             }

--- a/src/osvr/Util/LineLogger.cpp
+++ b/src/osvr/Util/LineLogger.cpp
@@ -66,7 +66,7 @@ LineLogger& LineLogger::operator<<(const char* what)
     return *this;
 }
 
-LineLogger& LineLogger::operator<<(const std::string& what)
+LineLogger& LineLogger::operator<<(const std::string what)
 {
     lineLogger_->operator<<(what);
     return *this;
@@ -129,13 +129,6 @@ LineLogger& LineLogger::operator<<(float what)
 LineLogger& LineLogger::operator<<(char what)
 {
     lineLogger_->operator<<(what);
-    return *this;
-}
-
-template<typename T>
-LineLogger& LineLogger::operator<<(T&& what)
-{
-    lineLogger_->operator<<(std::forward<T>(what));
     return *this;
 }
 

--- a/src/osvr/Util/LineLogger.cpp
+++ b/src/osvr/Util/LineLogger.cpp
@@ -1,0 +1,156 @@
+/** @file
+    @brief Implementation
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Util/LineLogger.h>
+
+// Library/third-party includes
+#include <spdlog/spdlog.h>
+
+// Standard includes
+#include <algorithm>        // for std::move
+#include <utility>          // for std::forward
+#include <string>           // for std::string
+
+namespace osvr {
+namespace util {
+namespace log {
+namespace detail {
+
+LineLogger::LineLogger(spdlog::details::line_logger&& line_logger) : lineLogger_(new ::spdlog::details::line_logger(std::move(line_logger)))
+{
+    // do nothing
+}
+
+LineLogger::~LineLogger()
+{
+    // TODO
+}
+
+void LineLogger::write(const char* what)
+{
+    lineLogger_->write(what);
+}
+
+template <typename... Args>
+void LineLogger::write(const char* fmt, Args&&... args)
+{
+    lineLogger_->write(fmt, std::forward<Args>(args)...);
+}
+
+LineLogger& LineLogger::operator<<(const char* what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(const std::string& what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(int what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(unsigned int what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(long what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(unsigned long what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(long long what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(unsigned long long what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(double what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(long double what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(float what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+LineLogger& LineLogger::operator<<(char what)
+{
+    lineLogger_->operator<<(what);
+    return *this;
+}
+
+template<typename T>
+LineLogger& LineLogger::operator<<(T&& what)
+{
+    lineLogger_->operator<<(std::forward<T>(what));
+    return *this;
+}
+
+void LineLogger::disable()
+{
+    lineLogger_->disable();
+}
+
+bool LineLogger::is_enabled() const
+{
+    return lineLogger_->is_enabled();
+}
+
+} // end namespace detail
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+

--- a/src/osvr/Util/Log.cpp
+++ b/src/osvr/Util/Log.cpp
@@ -25,6 +25,7 @@
 
 // Internal Includes
 #include <osvr/Util/Log.h>
+#include <osvr/Util/LogConfig.h>    // for OSVR_UTIL_LOG_SINGLETON
 #include <osvr/Util/LogSinks.h>
 #include <osvr/Util/PlatformConfig.h>
 #include <osvr/Util/GetEnvironmentVariable.h>
@@ -36,8 +37,6 @@
 // Standard includes
 #include <memory>           // for std::make_shared, std::shared_ptr
 #include <string>           // for std::string
-
-#cmakedefine OSVR_UTIL_LOG_SINGLETON
 
 #ifdef OSVR_UTIL_LOG_SINGLETON
 #include <osvr/Util/LogRegistry.h>

--- a/src/osvr/Util/Log.cpp
+++ b/src/osvr/Util/Log.cpp
@@ -52,6 +52,8 @@ namespace util {
         LoggerPtr make_logger(const std::string &logger_name) {
             return LogRegistry::instance().getOrCreateLogger(logger_name);
         }
+
+        void flush() { LogRegistry::instance().flush(); }
 #else
         /*
          * This implementation avoids using a singleton.  The downside is that
@@ -70,6 +72,10 @@ namespace util {
                 std::make_shared< ::spdlog::logger>(logger_name, sink);
             spd_logger->set_pattern("%b %d %T.%e %l %n: %v");
             return std::make_shared<Logger>(spd_logger);
+        }
+
+        void flush() {
+            // no-op in the absence of a logger registry.
         }
 #endif
 

--- a/src/osvr/Util/Log.cpp
+++ b/src/osvr/Util/Log.cpp
@@ -24,19 +24,19 @@
 // limitations under the License.
 
 // Internal Includes
+#include <osvr/Util/GetEnvironmentVariable.h>
 #include <osvr/Util/Log.h>
-#include <osvr/Util/LogConfig.h>    // for OSVR_UTIL_LOG_SINGLETON
+#include <osvr/Util/LogConfig.h> // for OSVR_UTIL_LOG_SINGLETON
 #include <osvr/Util/LogSinks.h>
 #include <osvr/Util/PlatformConfig.h>
-#include <osvr/Util/GetEnvironmentVariable.h>
 
 // Library/third-party includes
-#include <spdlog/spdlog.h>
 #include <boost/filesystem.hpp>
+#include <spdlog/spdlog.h>
 
 // Standard includes
-#include <memory>           // for std::make_shared, std::shared_ptr
-#include <string>           // for std::string
+#include <memory> // for std::make_shared, std::shared_ptr
+#include <string> // for std::string
 
 #ifdef OSVR_UTIL_LOG_SINGLETON
 #include <osvr/Util/LogRegistry.h>
@@ -44,87 +44,90 @@
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
 // TODO if OSVR_ANDROID, use android sink
 
 #ifdef OSVR_UTIL_LOG_SINGLETON
-LoggerPtr make_logger(const std::string& logger_name)
-{
-    return LogRegistry::instance().getOrCreateLogger(logger_name);
-}
+        LoggerPtr make_logger(const std::string &logger_name) {
+            return LogRegistry::instance().getOrCreateLogger(logger_name);
+        }
 #else
-/*
- * This implementation avoids using a singleton.  The downside is that each call
- * to make_logger() will generate a new logger instead of reusing an existing
- * logger of the same name.
- *
- * It is recommended that you store the LoggerPtr locally to avoid this penalty.
- */
-LoggerPtr make_logger(const std::string& logger_name)
-{
-    // FIXME use custom OSVR logger that splits output to STDOUT and STDERR and
-    // log files based on severity levels, etc.
-    auto sink = std::make_shared<stdout_sink_mt>();
-    auto spd_logger = std::make_shared<::spdlog::logger>(logger_name, sink);
-    spd_logger->set_pattern("%b %d %T.%e %l %n: %v");
-    return std::make_shared<Logger>(spd_logger);
-}
+        /*
+         * This implementation avoids using a singleton.  The downside is that
+         * each call to make_logger() will generate a new logger instead of
+         * reusing an existing logger of the same name (and loggers do not have
+         * custom dual sinks, etc.)
+         *
+         * It is recommended that you store the LoggerPtr locally to avoid the
+         * performance penalty if you must compile without the singleton.
+         */
+        LoggerPtr make_logger(const std::string &logger_name) {
+            /// @todo use custom OSVR logger that splits output to STDOUT and
+            /// STDERR and log files based on severity levels, etc.
+            auto sink = std::make_shared<stdout_sink_mt>();
+            auto spd_logger =
+                std::make_shared< ::spdlog::logger>(logger_name, sink);
+            spd_logger->set_pattern("%b %d %T.%e %l %n: %v");
+            return std::make_shared<Logger>(spd_logger);
+        }
 #endif
 
-std::string getLoggingDirectory(bool make_dir)
-{
-    namespace fs = boost::filesystem;
-    using osvr::util::getEnvironmentVariable;
-    fs::path log_dir;
+        std::string getLoggingDirectory(bool make_dir) {
+            namespace fs = boost::filesystem;
+            using osvr::util::getEnvironmentVariable;
+            fs::path log_dir;
 
 #if defined(OSVR_LINUX)
-    // There's currently no great location for storing log files in the XDG
-    // system. (See the STATE proposal by Debian
-    // <https://wiki.debian.org/XDGBaseDirectorySpecification#Proposal:_STATE_directory>.)
-    // So for now, we'll store our log files in the $XDG_CACHE_HOME directory.
-    //
-    // $XDG_CACHE_HOME defines the base directory relative to which user
-    // specific non-essential data files should be stored. If $XDG_CACHE_HOME is
-    // either not set or empty, a default equal to $HOME/.cache should be used.
-    auto xdg_cache_dir = getEnvironmentVariable("XDG_CACHE_HOME");
-    if (xdg_cache_dir) {
-        log_dir = *xdg_cache_dir;
-    } else {
-        auto home_dir = getEnvironmentVariable("HOME");
-        log_dir = fs::path(*home_dir) / ".cache";
-    }
-    log_dir /= fs::path("osvr") / "logs";
+            // There's currently no great location for storing log files in the
+            // XDG system. (See the STATE proposal by Debian
+            // <https://wiki.debian.org/XDGBaseDirectorySpecification#Proposal:_STATE_directory>.)
+            // So for now, we'll store our log files in the $XDG_CACHE_HOME
+            // directory.
+            //
+            // $XDG_CACHE_HOME defines the base directory relative to which user
+            // specific non-essential data files should be stored. If
+            // $XDG_CACHE_HOME is either not set or empty, a default equal to
+            // $HOME/.cache should be used.
+            auto xdg_cache_dir = getEnvironmentVariable("XDG_CACHE_HOME");
+            if (xdg_cache_dir) {
+                log_dir = *xdg_cache_dir;
+            } else {
+                auto home_dir = getEnvironmentVariable("HOME");
+                log_dir = fs::path(*home_dir) / ".cache";
+            }
+            log_dir /= fs::path("osvr") / "logs";
 #elif defined(OSVR_MACOSX)
-    auto home_dir = getEnvironmentVariable("HOME");
-    if (home_dir) {
-        log_dir = *home_dir;
-    }
-    log_dir /= "Library" / fs::path("Logs") / "OSVR";
+            auto home_dir = getEnvironmentVariable("HOME");
+            if (home_dir) {
+                log_dir = *home_dir;
+            }
+            log_dir /= "Library" / fs::path("Logs") / "OSVR";
 #elif defined(OSVR_WINDOWS)
-    auto local_app_dir = getEnvironmentVariable("LocalAppData");
-    if (local_app_dir) {
-        log_dir = *local_app_dir;
-    } else {
-        log_dir = "c:/";
-    }
-    log_dir /= fs::path("OSVR") / "Logs";
+            /// @todo there's actually a win32 api call to get localappdata
+            /// that's preferred to the env var.
+            auto local_app_dir = getEnvironmentVariable("LocalAppData");
+            if (local_app_dir) {
+                log_dir = *local_app_dir;
+            } else {
+                log_dir = "c:/";
+            }
+            log_dir /= fs::path("OSVR") / "Logs";
 #endif
 
-    if (fs::is_directory(log_dir))
-        return log_dir.string();
+            if (fs::is_directory(log_dir))
+                return log_dir.string();
 
-    if (make_dir) {
-        auto success = fs::create_directories(log_dir);
-        if (!success) {
-            log_dir.clear();
+            if (make_dir) {
+                auto success = fs::create_directories(log_dir);
+                if (!success) {
+                    log_dir.clear();
+                }
+            }
+
+            return log_dir.string();
         }
-    }
 
-    return log_dir.string();
-}
-
-} // end namespace log
+    } // end namespace log
 } // end namespace util
 } // end namespace osvr
-

--- a/src/osvr/Util/Log.cpp.in
+++ b/src/osvr/Util/Log.cpp.in
@@ -1,0 +1,131 @@
+/** @file
+    @brief Implementation
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Util/Log.h>
+#include <osvr/Util/LogSinks.h>
+#include <osvr/Util/PlatformConfig.h>
+#include <osvr/Util/GetEnvironmentVariable.h>
+
+// Library/third-party includes
+#include <spdlog/spdlog.h>
+#include <boost/filesystem.hpp>
+
+// Standard includes
+#include <memory>           // for std::make_shared, std::shared_ptr
+#include <string>           // for std::string
+
+#cmakedefine OSVR_UTIL_LOG_SINGLETON
+
+#ifdef OSVR_UTIL_LOG_SINGLETON
+#include <osvr/Util/LogRegistry.h>
+#endif
+
+namespace osvr {
+namespace util {
+namespace log {
+
+// TODO if OSVR_ANDROID, use android sink
+
+#ifdef OSVR_UTIL_LOG_SINGLETON
+LoggerPtr make_logger(const std::string& logger_name)
+{
+    return LogRegistry::instance().getOrCreateLogger(logger_name);
+}
+#else
+/*
+ * This implementation avoids using a singleton.  The downside is that each call
+ * to make_logger() will generate a new logger instead of reusing an existing
+ * logger of the same name.
+ *
+ * It is recommended that you store the LoggerPtr locally to avoid this penalty.
+ */
+LoggerPtr make_logger(const std::string& logger_name)
+{
+    // FIXME use custom OSVR logger that splits output to STDOUT and STDERR and
+    // log files based on severity levels, etc.
+    auto sink = std::make_shared<stdout_sink_mt>();
+    auto spd_logger = std::make_shared<::spdlog::logger>(logger_name, sink);
+    spd_logger->set_pattern("%b %d %T.%e %l %n: %v");
+    return std::make_shared<Logger>(spd_logger);
+}
+#endif
+
+std::string getLoggingDirectory(bool make_dir)
+{
+    namespace fs = boost::filesystem;
+    using osvr::util::getEnvironmentVariable;
+    fs::path log_dir;
+
+#if defined(OSVR_LINUX)
+    // There's currently no great location for storing log files in the XDG
+    // system. (See the STATE proposal by Debian
+    // <https://wiki.debian.org/XDGBaseDirectorySpecification#Proposal:_STATE_directory>.)
+    // So for now, we'll store our log files in the $XDG_CACHE_HOME directory.
+    //
+    // $XDG_CACHE_HOME defines the base directory relative to which user
+    // specific non-essential data files should be stored. If $XDG_CACHE_HOME is
+    // either not set or empty, a default equal to $HOME/.cache should be used.
+    auto xdg_cache_dir = getEnvironmentVariable("XDG_CACHE_HOME");
+    if (xdg_cache_dir) {
+        log_dir = *xdg_cache_dir;
+    } else {
+        auto home_dir = getEnvironmentVariable("HOME");
+        log_dir = fs::path(*home_dir) / ".cache";
+    }
+    log_dir /= fs::path("osvr") / "logs";
+#elif defined(OSVR_MACOSX)
+    auto home_dir = getEnvironmentVariable("HOME");
+    if (home_dir) {
+        log_dir = *home_dir;
+    }
+    log_dir /= "Library" / fs::path("Logs") / "OSVR";
+#elif defined(OSVR_WINDOWS)
+    auto local_app_dir = getEnvironmentVariable("LocalAppData");
+    if (local_app_dir) {
+        log_dir = *local_app_dir;
+    } else {
+        log_dir = "c:/";
+    }
+    log_dir /= fs::path("OSVR") / "Logs";
+#endif
+
+    if (fs::is_directory(log_dir))
+        return log_dir.string();
+
+    if (make_dir) {
+        auto success = fs::create_directories(log_dir);
+        if (!success) {
+            log_dir.clear();
+        }
+    }
+
+    return log_dir.string();
+}
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+

--- a/src/osvr/Util/LogConfig.h.in
+++ b/src/osvr/Util/LogConfig.h.in
@@ -1,0 +1,41 @@
+/** @file
+    @brief Compile-time logging configuration
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+#ifndef INCLUDED_LogConfig_h_in_GUID_55FF1F50_4D07_44A3_AEFA_945419E803C6
+#define INCLUDED_LogConfig_h_in_GUID_55FF1F50_4D07_44A3_AEFA_945419E803C6
+
+#cmakedefine OSVR_UTIL_LOG_SINGLETON
+
+#endif // INCLUDED_LogConfig_h_in_GUID_55FF1F50_4D07_44A3_AEFA_945419E803C6
+

--- a/src/osvr/Util/LogDefaults.h
+++ b/src/osvr/Util/LogDefaults.h
@@ -1,0 +1,48 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogDefaults_h_GUID_A18EEB05_68C0_45AA_C97B_F7D6CEEA1330
+#define INCLUDED_LogDefaults_h_GUID_A18EEB05_68C0_45AA_C97B_F7D6CEEA1330
+
+// Internal Includes
+#include <osvr/Util/LogLevel.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace util {
+    namespace log {
+        static const auto DEFAULT_PATTERN = "%b %d %T.%e %l [%n]: %v";
+        static const auto DEFAULT_LEVEL = LogLevel::trace;
+        static const auto DEFAULT_CONSOLE_LEVEL = LogLevel::info;
+        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::error;
+    } // end namespace log
+} // end namespace util
+} // end namespace osvr
+
+#endif // INCLUDED_LogDefaults_h_GUID_A18EEB05_68C0_45AA_C97B_F7D6CEEA1330

--- a/src/osvr/Util/LogDefaults.h
+++ b/src/osvr/Util/LogDefaults.h
@@ -40,7 +40,7 @@ namespace util {
         static const auto DEFAULT_PATTERN = "%b %d %T.%e %l [%n]: %v";
         static const auto DEFAULT_LEVEL = LogLevel::trace;
         static const auto DEFAULT_CONSOLE_LEVEL = LogLevel::info;
-        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::notice;
+        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::info;
     } // end namespace log
 } // end namespace util
 } // end namespace osvr

--- a/src/osvr/Util/LogDefaults.h
+++ b/src/osvr/Util/LogDefaults.h
@@ -40,7 +40,7 @@ namespace util {
         static const auto DEFAULT_PATTERN = "%b %d %T.%e %l [%n]: %v";
         static const auto DEFAULT_LEVEL = LogLevel::trace;
         static const auto DEFAULT_CONSOLE_LEVEL = LogLevel::info;
-        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::error;
+        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::notice;
     } // end namespace log
 } // end namespace util
 } // end namespace osvr

--- a/src/osvr/Util/LogLevelTranslate.h
+++ b/src/osvr/Util/LogLevelTranslate.h
@@ -1,0 +1,98 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LogLevelTranslate_h_GUID_24C67818_0BC8_41B9_7003_1098631ED86F
+#define INCLUDED_LogLevelTranslate_h_GUID_24C67818_0BC8_41B9_7003_1098631ED86F
+
+// Internal Includes
+#include <osvr/Util/LogLevel.h>
+
+// Library/third-party includes
+#include <spdlog/common.h>
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace util {
+    namespace log {
+
+        /// Maps OSVR log levels into spdlog levels.
+        inline spdlog::level::level_enum
+        convertToLevelEnum(OSVR_LogLevel level) {
+            if (level <= OSVR_LOGLEVEL_TRACE) {
+                return spdlog::level::trace;
+            }
+            if (level <= OSVR_LOGLEVEL_DEBUG) {
+                return spdlog::level::debug;
+            }
+            if (level <= OSVR_LOGLEVEL_INFO) {
+                return spdlog::level::info;
+            }
+            if (level <= OSVR_LOGLEVEL_NOTICE) {
+                return spdlog::level::notice;
+            }
+            if (level <= OSVR_LOGLEVEL_WARN) {
+                return spdlog::level::warn;
+            }
+            if (level <= OSVR_LOGLEVEL_ERR) {
+                return spdlog::level::err;
+            }
+            return spdlog::level::critical;
+        }
+
+        inline spdlog::level::level_enum convertToLevelEnum(LogLevel level) {
+            return convertToLevelEnum(
+                static_cast<OSVR_LogLevel>(static_cast<int>(level)));
+        }
+
+        /// The reverse mapping.
+        inline LogLevel convertFromLevelEnum(spdlog::level::level_enum level) {
+            switch (level) {
+            case spdlog::level::trace:
+                return LogLevel::trace;
+            case spdlog::level::debug:
+                return LogLevel::debug;
+            case spdlog::level::info:
+                return LogLevel::info;
+            case spdlog::level::notice:
+                return LogLevel::notice;
+            case spdlog::level::warn:
+                return LogLevel::warn;
+            case spdlog::level::err:
+                return LogLevel::err;
+            case spdlog::level::critical:
+            case spdlog::level::alert:
+            case spdlog::level::emerg:
+                return LogLevel::critical;
+            default:
+                return LogLevel::critical;
+            }
+        }
+
+    } // namespace log
+} // namespace util
+} // namespace osvr
+
+#endif // INCLUDED_LogLevelTranslate_h_GUID_24C67818_0BC8_41B9_7003_1098631ED86F

--- a/src/osvr/Util/LogLevelTranslate.h
+++ b/src/osvr/Util/LogLevelTranslate.h
@@ -56,7 +56,7 @@ namespace util {
             if (level <= OSVR_LOGLEVEL_WARN) {
                 return spdlog::level::warn;
             }
-            if (level <= OSVR_LOGLEVEL_ERR) {
+            if (level <= OSVR_LOGLEVEL_ERROR) {
                 return spdlog::level::err;
             }
             return spdlog::level::critical;
@@ -81,7 +81,7 @@ namespace util {
             case spdlog::level::warn:
                 return LogLevel::warn;
             case spdlog::level::err:
-                return LogLevel::err;
+                return LogLevel::error;
             case spdlog::level::critical:
             case spdlog::level::alert:
             case spdlog::level::emerg:

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -26,6 +26,7 @@
 // Internal Includes
 #include <osvr/Util/LogRegistry.h>
 
+#include "LogDefaults.h"
 #include "LogLevelTranslate.h"
 
 #include <osvr/Util/Log.h>
@@ -80,10 +81,6 @@ namespace sinks {
 namespace osvr {
 namespace util {
     namespace log {
-        static const auto DEFAULT_PATTERN = "%b %d %T.%e %l [%n]: %v";
-        static const auto DEFAULT_LEVEL = LogLevel::trace;
-        static const auto DEFAULT_CONSOLE_LEVEL = LogLevel::info;
-        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::error;
         LogRegistry &LogRegistry::instance() {
             static LogRegistry instance_;
             return instance_;

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -61,7 +61,7 @@ LoggerPtr LogRegistry::getOrCreateLogger(const std::string& logger_name)
 
     spd_logger->set_pattern("%b %d %T.%e %l [%n]: %v");
     spd_logger->set_level(spdlog::level::trace);
-    spd_logger->flush_on(spdlog::level::error);
+    spd_logger->flush_on(spdlog::level::err);
 
     return std::make_shared<Logger>(spd_logger);
 }

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -36,7 +36,7 @@
 #include <boost/filesystem.hpp>
 
 // Standard includes
-// - none
+#include <iostream>
 
 namespace osvr {
 namespace util {
@@ -96,14 +96,20 @@ LogRegistry::LogRegistry() : sinks_()
 #endif
 
     // File sink - rotates daily
-    size_t q_size = 1048576; // queue size must be power of 2
-    spdlog::set_async_mode(q_size);
-    namespace fs = boost::filesystem;
-    auto base_name = fs::path(getLoggingDirectory(true));
-    if (!base_name.empty()) {
-        base_name /= "osvr";
-        auto daily_file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(base_name.string().c_str(), "log", 0, 0, false);
-        sinks_.push_back(daily_file_sink);
+    try {
+        size_t q_size = 1048576; // queue size must be power of 2
+        spdlog::set_async_mode(q_size);
+        namespace fs = boost::filesystem;
+        auto base_name = fs::path(getLoggingDirectory(true));
+        if (!base_name.empty()) {
+            base_name /= "osvr";
+            auto daily_file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(base_name.string().c_str(), "log", 0, 0, false);
+            sinks_.push_back(daily_file_sink);
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[OSVR] Error creating log file sink: " << e.what() << ". Will log to console only." << std::endl;
+    } catch (...) {
+        std::cerr << "[OSVR] Error creating log file sink. Will log to console only." << std::endl;
     }
 }
 

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -24,101 +24,159 @@
 // limitations under the License.
 
 // Internal Includes
-#include <osvr/Util/LogRegistry.h>
 #include <osvr/Util/Log.h>
-#include <osvr/Util/Logger.h>
 #include <osvr/Util/LogLevel.h>
+#include <osvr/Util/LogRegistry.h>
+#include <osvr/Util/Logger.h>
 #include <osvr/Util/PlatformConfig.h>
 
 // Library/third-party includes
-#include <spdlog/spdlog.h>
-#include <spdlog/sinks/ansicolor_sink.h>
 #include <boost/filesystem.hpp>
+#include <spdlog/common.h>
+#include <spdlog/sinks/ansicolor_sink.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
 
 // Standard includes
 #include <iostream>
+#include <utility>
+
+namespace spdlog {
+namespace sinks {
+    /// A decorator around another sink that applies a custom log level filter.
+    class filter_sink : public sink {
+      public:
+        filter_sink(sink_ptr wrapped_sink, level::level_enum filter_level);
+        virtual ~filter_sink() {}
+        void log(const details::log_msg &msg) override;
+        void flush() override { sink_->flush(); }
+        void set_level(level::level_enum filter_level);
+
+      private:
+        sink_ptr sink_;
+        level::level_enum level_;
+    };
+    inline filter_sink::filter_sink(sink_ptr wrapped_sink,
+                                    level::level_enum filter_level)
+        : sink_(std::move(wrapped_sink)), level_(filter_level) {}
+
+    inline void filter_sink::log(const details::log_msg &msg) {
+        if (msg.level < level_) {
+            return;
+        }
+        sink_->log(msg);
+    }
+
+    void filter_sink::set_level(level::level_enum filter_level) {
+        level_ = filter_level;
+    }
+
+} // namespace sinks
+} // namespace spdlog
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
+        static const auto DEFAULT_PATTERN = "%b %d %T.%e %l [%n]: %v";
+        static const auto DEFAULT_LEVEL = spdlog::level::trace;
+        static const auto DEFAULT_FLUSH_LEVEL = spdlog::level::err;
+        LogRegistry &LogRegistry::instance() {
+            static LogRegistry instance_;
+            return instance_;
+        }
 
-LogRegistry& LogRegistry::instance()
-{
-    static LogRegistry instance_;
-    return instance_;
-}
+        LoggerPtr
+        LogRegistry::getOrCreateLogger(const std::string &logger_name) {
+            // If logger already exists, return a copy of it
+            auto spd_logger = spdlog::get(logger_name);
+            if (!spd_logger) {
+                // Bummer, it didn't exist. We'll create one from scratch.
+                spd_logger = spdlog::details::registry::instance().create(
+                    logger_name, begin(sinks_), end(sinks_));
+            }
 
-LoggerPtr LogRegistry::getOrCreateLogger(const std::string& logger_name)
-{
-    // If logger already exists, return a copy of it
-    auto spd_logger = spdlog::get(logger_name);
-    if (!spd_logger) {
-        // Bummer, it didn't exist. We'll create one from scratch.
-        spd_logger = spdlog::details::registry::instance().create(logger_name, begin(sinks_), end(sinks_));
-    }
+            spd_logger->set_pattern(DEFAULT_PATTERN);
+            spd_logger->set_level(DEFAULT_LEVEL);
+            spd_logger->flush_on(DEFAULT_FLUSH_LEVEL);
 
-    spd_logger->set_pattern("%b %d %T.%e %l [%n]: %v");
-    spd_logger->set_level(spdlog::level::trace);
-    spd_logger->flush_on(spdlog::level::err);
+            return std::make_shared<Logger>(spd_logger);
+        }
 
-    return std::make_shared<Logger>(spd_logger);
-}
+        void LogRegistry::setPattern(const std::string &pattern) {
+            spdlog::set_pattern(pattern.c_str());
+        }
 
-void setPattern(const std::string& pattern)
-{
-    spdlog::set_pattern(pattern.c_str());
-}
+        void LogRegistry::setLevel(LogLevel severity) {
+            spdlog::set_level(static_cast<spdlog::level::level_enum>(severity));
+        }
 
-void setLevel(LogLevel severity)
-{
-    spdlog::set_level(static_cast<spdlog::level::level_enum>(severity));
-}
-
-LogRegistry::LogRegistry() : sinks_()
-{
-    // Set default pattern and level
-    spdlog::set_pattern("%b %d %T.%e %l [%n]: %v");
-    spdlog::set_level(static_cast<spdlog::level::level_enum>(LogLevel::info));
-
-    // Instantiate console and file sinks
-
-    // Console sink
-    auto console_out = spdlog::sinks::stderr_sink_mt::instance();
-    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(console_out); // taste the rainbow!
+        static inline spdlog::sink_ptr getConsoleSink() {
+            // Console sink
+            auto console_out = spdlog::sinks::stderr_sink_mt::instance();
 #if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
-    sinks_.push_back(color_sink);
-#elif defined(OSVR_ANDROID)
-    auto android_sink = spdlog::sinks::android_sink_mt("OSVR");
-    sinks_.push_back(android_sink);
+            auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(
+                console_out); // taste the rainbow!
+            return color_sink;
 #else
-    // No color for Windows yet (and not tested on other platforms)
-    sinks_.push_back(console_out);
+            // No color for Windows yet (and not tested on other platforms)
+            return console_out;
+#endif
+        }
+
+        void LogRegistry::setConsoleLevel(LogLevel severity) {
+            if (console_filter_) {
+                console_filter_->set_level(
+                    static_cast<spdlog::level::level_enum>(severity));
+            }
+        }
+
+        LogRegistry::LogRegistry() : sinks_() {
+            // Set default pattern and level
+            spdlog::set_pattern(DEFAULT_PATTERN);
+            spdlog::set_level(
+                static_cast<spdlog::level::level_enum>(LogLevel::info));
+
+// Instantiate console and file sinks
+
+#if defined(OSVR_ANDROID)
+            // Android doesn't have a console, it has logcat.
+            auto android_sink = spdlog::sinks::android_sink_mt("OSVR");
+            sinks_.push_back(android_sink);
+#else
+            // Console sink
+            auto console_sink = getConsoleSink();
+            console_filter_ = std::make_shared<spdlog::sinks::filter_sink>(
+                console_sink, spdlog::level::info);
+            sinks_.push_back(console_filter_);
 #endif
 
-    // File sink - rotates daily
-    try {
-        size_t q_size = 1048576; // queue size must be power of 2
-        spdlog::set_async_mode(q_size);
-        namespace fs = boost::filesystem;
-        auto base_name = fs::path(getLoggingDirectory(true));
-        if (!base_name.empty()) {
-            base_name /= "osvr";
-            auto daily_file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(base_name.string().c_str(), "log", 0, 0, false);
-            sinks_.push_back(daily_file_sink);
+            // File sink - rotates daily
+            try {
+                size_t q_size = 1048576; // queue size must be power of 2
+                spdlog::set_async_mode(q_size);
+                namespace fs = boost::filesystem;
+                auto base_name = fs::path(getLoggingDirectory(true));
+                if (!base_name.empty()) {
+                    base_name /= "osvr";
+                    auto daily_file_sink =
+                        std::make_shared<spdlog::sinks::daily_file_sink_mt>(
+                            base_name.string().c_str(), "log", 0, 0, false);
+                    sinks_.push_back(daily_file_sink);
+                }
+            } catch (const std::exception &e) {
+                std::cerr << "[OSVR] Error creating log file sink: " << e.what()
+                          << ". Will log to console only." << std::endl;
+            } catch (...) {
+                std::cerr << "[OSVR] Error creating log file sink. Will log to "
+                             "console only."
+                          << std::endl;
+            }
         }
-    } catch (const std::exception& e) {
-        std::cerr << "[OSVR] Error creating log file sink: " << e.what() << ". Will log to console only." << std::endl;
-    } catch (...) {
-        std::cerr << "[OSVR] Error creating log file sink. Will log to console only." << std::endl;
-    }
-}
 
-LogRegistry::~LogRegistry()
-{
-    // do nothing
-}
+        LogRegistry::~LogRegistry() {
+            // do nothing
+        }
 
-} // end namespace log
+    } // end namespace log
 } // end namespace util
 } // end namespace osvr
-

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -102,6 +102,12 @@ namespace util {
             return std::make_shared<Logger>(spd_logger);
         }
 
+        void LogRegistry::flush() {
+            for (auto &sink : sinks_) {
+                sink->flush();
+            }
+        }
+
         void LogRegistry::setPattern(const std::string &pattern) {
             spdlog::set_pattern(pattern.c_str());
         }
@@ -174,7 +180,8 @@ namespace util {
         }
 
         LogRegistry::~LogRegistry() {
-            // do nothing
+            // do nothing but flush
+            flush();
         }
 
     } // end namespace log

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -83,7 +83,7 @@ namespace util {
         static const auto DEFAULT_PATTERN = "%b %d %T.%e %l [%n]: %v";
         static const auto DEFAULT_LEVEL = LogLevel::trace;
         static const auto DEFAULT_CONSOLE_LEVEL = LogLevel::info;
-        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::err;
+        static const auto DEFAULT_FLUSH_LEVEL = LogLevel::error;
         LogRegistry &LogRegistry::instance() {
             static LogRegistry instance_;
             return instance_;

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -90,7 +90,7 @@ LogRegistry::LogRegistry() : sinks_()
 #if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
     sinks_.push_back(color_sink);
 #elif defined(OSVR_ANDROID)
-    auto android_sink = spdlog::sinks::android_sink_mt();
+    auto android_sink = spdlog::sinks::android_sink_mt("OSVR");
     sinks_.push_back(android_sink);
 #else
     // No color for Windows yet (and not tested on other platforms)

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -1,0 +1,119 @@
+/** @file
+    @brief Regstry to maintain instantiated loggers and global settings.
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Util/LogRegistry.h>
+#include <osvr/Util/Log.h>
+#include <osvr/Util/Logger.h>
+#include <osvr/Util/LogLevel.h>
+#include <osvr/Util/PlatformConfig.h>
+
+// Library/third-party includes
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/ansicolor_sink.h>
+#include <boost/filesystem.hpp>
+
+// Standard includes
+// - none
+
+namespace osvr {
+namespace util {
+namespace log {
+
+LogRegistry& LogRegistry::instance()
+{
+    static LogRegistry instance_;
+    return instance_;
+}
+
+LoggerPtr LogRegistry::getOrCreateLogger(const std::string& logger_name)
+{
+    // If logger already exists, return a copy of it
+    auto spd_logger = spdlog::get(logger_name);
+    if (spd_logger)
+        return std::make_shared<Logger>(spd_logger);
+
+    // Bummer, it didn't exist. We'll create one from scratch.
+
+    spd_logger = spdlog::details::registry::instance().create(logger_name, begin(sinks_), end(sinks_));
+
+    spd_logger->set_pattern("%b %d %T.%e %l [%n]: %v");
+    spd_logger->set_level(spdlog::level::trace);
+
+    return std::make_shared<Logger>(spd_logger);
+}
+
+void setPattern(const std::string& pattern)
+{
+    spdlog::set_pattern(pattern.c_str());
+}
+
+void setLevel(LogLevel severity)
+{
+    spdlog::set_level(static_cast<spdlog::level::level_enum>(severity));
+}
+
+LogRegistry::LogRegistry() : sinks_()
+{
+    // Set default pattern and level
+    spdlog::set_pattern("%b %d %T.%e %l [%n]: %v");
+    spdlog::set_level(static_cast<spdlog::level::level_enum>(LogLevel::info));
+
+    // Instantiate console and file sinks
+
+    // Console sink
+    auto console_out = spdlog::sinks::stderr_sink_mt::instance();
+    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(console_out); // taste the rainbow!
+#if defined(OSVR_LINUX) || defined(OSVR_MACOSX)
+    sinks_.push_back(color_sink);
+#elif defined(OSVR_ANDROID)
+    auto android_sink = spdlog::sinks::android_sink_mt();
+    sinks_.push_back(android_sink);
+#else
+    // No color for Windows yet (and not tested on other platforms)
+    sinks_.push_back(console_out);
+#endif
+
+    // File sink - rotates daily
+    size_t q_size = 1048576; // queue size must be power of 2
+    spdlog::set_async_mode(q_size);
+    namespace fs = boost::filesystem;
+    auto base_name = fs::path(getLoggingDirectory(true));
+    if (!base_name.empty()) {
+        base_name /= "osvr";
+        auto daily_file_sink = std::make_shared<spdlog::sinks::daily_file_sink_mt>(base_name.string().c_str(), "log", 0, 0, false);
+        sinks_.push_back(daily_file_sink);
+    }
+}
+
+LogRegistry::~LogRegistry()
+{
+    // do nothing
+}
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -61,6 +61,7 @@ LoggerPtr LogRegistry::getOrCreateLogger(const std::string& logger_name)
 
     spd_logger->set_pattern("%b %d %T.%e %l [%n]: %v");
     spd_logger->set_level(spdlog::level::trace);
+    spd_logger->flush_on(spdlog::level::error);
 
     return std::make_shared<Logger>(spd_logger);
 }

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -52,12 +52,10 @@ LoggerPtr LogRegistry::getOrCreateLogger(const std::string& logger_name)
 {
     // If logger already exists, return a copy of it
     auto spd_logger = spdlog::get(logger_name);
-    if (spd_logger)
-        return std::make_shared<Logger>(spd_logger);
-
-    // Bummer, it didn't exist. We'll create one from scratch.
-
-    spd_logger = spdlog::details::registry::instance().create(logger_name, begin(sinks_), end(sinks_));
+    if (!spd_logger) {
+        // Bummer, it didn't exist. We'll create one from scratch.
+        spd_logger = spdlog::details::registry::instance().create(logger_name, begin(sinks_), end(sinks_));
+    }
 
     spd_logger->set_pattern("%b %d %T.%e %l [%n]: %v");
     spd_logger->set_level(spdlog::level::trace);

--- a/src/osvr/Util/LogSinks.cpp
+++ b/src/osvr/Util/LogSinks.cpp
@@ -1,0 +1,56 @@
+/** @file
+    @brief Implementation of logging sinks for std::cout and std::cerr.
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Util/LogSinks.h>
+
+// Library/third-party includes
+#include <spdlog/spdlog.h>
+
+// Standard includes
+#include <iostream>
+
+namespace osvr {
+namespace util {
+namespace log {
+
+/*
+template <typename Mutex>
+stdout_sink<Mutex>::stdout_sink() : ::spdlog::sinks::ostream_sink<Mutex>(std::cout, true)
+{
+    // do nothing
+}
+
+template <typename Mutex>
+stderr_sink<Mutex>::stderr_sink() : ::spdlog::sinks::ostream_sink<Mutex>(std::cerr, true)
+{
+    // do nothing
+}
+*/
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -75,54 +75,6 @@ void Logger::setLogLevel(LogLevel level)
     logger_->set_level(static_cast<spdlog::level::level_enum>(level));
 }
 
-// Logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
-/*
-template <typename... Args> detail::LineLogger Logger::trace(const char* fmt, Args&&... args)
-{
-    return logger_->trace(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::debug(const char* fmt, Args&&... args)
-{
-    return logger_->debug(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::info(const char* fmt, Args&&... args)
-{
-    return logger_->info(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::notice(const char* fmt, Args&&... args)
-{
-    return logger_->notice(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::warn(const char* fmt, Args&&... args)
-{
-    return logger_->warn(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::error(const char* fmt, Args&&... args)
-{
-    return logger_->error(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::critical(const char* fmt, Args&&... args)
-{
-    return logger_->critical(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::alert(const char* fmt, Args&&... args)
-{
-    return logger_->alert(fmt, std::forward<Args>(args)...);
-}
-
-template <typename... Args> detail::LineLogger Logger::emerg(const char* fmt, Args&&... args)
-{
-    return logger_->emerg(fmt, std::forward<Args>(args)...);
-}
-*/
-
 detail::LineLogger Logger::trace(const char* fmt)
 {
     return logger_->trace(fmt);
@@ -167,53 +119,6 @@ detail::LineLogger Logger::emerg(const char* fmt)
 {
     return logger_->emerg(fmt);
 }
-
-// logger.info(msg) << ".." call style
-template <typename T> detail::LineLogger Logger::trace(T&& msg)
-{
-    return logger_->trace(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::debug(T&& msg)
-{
-    return logger_->debug(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::info(T&& msg)
-{
-    return logger_->info(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::notice(T&& msg)
-{
-    return logger_->notice(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::warn(T&& msg)
-{
-    return logger_->warn(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::error(T&& msg)
-{
-    return logger_->error(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::critical(T&& msg)
-{
-    return logger_->critical(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::alert(T&& msg)
-{
-    return logger_->alert(std::forward<T>(msg));
-}
-
-template <typename T> detail::LineLogger Logger::emerg(T&& msg)
-{
-    return logger_->emerg(std::forward<T>(msg));
-}
-
 
 
 // logger.info() << ".." call  style
@@ -262,32 +167,6 @@ detail::LineLogger Logger::emerg()
     return logger_->emerg();
 }
 
-// Logger.log(log_level, cppformat_string, arg1, arg2, arg3, ...) call style
-template <typename... Args>
-detail::LineLogger Logger::log(LogLevel level, const char* fmt, Args&&... args)
-{
-    switch (level) {
-    case LogLevel::trace:
-        return trace(fmt, std::forward<Args>(args)...);
-    case LogLevel::debug:
-        return debug(fmt, std::forward<Args>(args)...);
-    case LogLevel::info:
-        return info(fmt, std::forward<Args>(args)...);
-    case LogLevel::notice:
-        return notice(fmt, std::forward<Args>(args)...);
-    case LogLevel::warn:
-        return warn(fmt, std::forward<Args>(args)...);
-    case LogLevel::err:
-        return error(fmt, std::forward<Args>(args)...);
-    case LogLevel::critical:
-        return critical(fmt, std::forward<Args>(args)...);
-    case LogLevel::alert:
-        return alert(fmt, std::forward<Args>(args)...);
-    case LogLevel::emerg:
-        return emerg(fmt, std::forward<Args>(args)...);
-    }
-}
-
 // logger.log(log_level, msg) << ".." call style
 detail::LineLogger Logger::log(LogLevel level, const char* msg)
 {
@@ -313,34 +192,6 @@ detail::LineLogger Logger::log(LogLevel level, const char* msg)
     }
 
     return info(msg);
-}
-
-// logger.log(log_level, msg) << ".." call style
-template <typename T>
-detail::LineLogger Logger::log(LogLevel level, T&& msg)
-{
-    switch (level) {
-    case LogLevel::trace:
-        return trace(std::forward<T>(msg));
-    case LogLevel::debug:
-        return debug(std::forward<T>(msg));
-    case LogLevel::info:
-        return info(std::forward<T>(msg));
-    case LogLevel::notice:
-        return notice(std::forward<T>(msg));
-    case LogLevel::warn:
-        return warn(std::forward<T>(msg));
-    case LogLevel::err:
-        return error(std::forward<T>(msg));
-    case LogLevel::critical:
-        return critical(std::forward<T>(msg));
-    case LogLevel::alert:
-        return alert(std::forward<T>(msg));
-    case LogLevel::emerg:
-        return emerg(std::forward<T>(msg));
-    }
-
-    return info(std::forward<T>(msg));
 }
 
 // logger.log(log_level) << ".." call  style
@@ -370,18 +221,10 @@ detail::LineLogger Logger::log(LogLevel level)
     return info();
 }
 
-template <typename... Args>
-detail::LineLogger Logger::force_log(LogLevel level, const char* fmt, Args&&... args)
-{
-    auto lvl = static_cast<spdlog::level::level_enum>(level);
-    return logger_->force_log(lvl, fmt, std::forward<Args>(args)...);
-}
-
 void Logger::flush()
 {
     logger_->flush();
 }
-
 
 } // end namespace log
 } // end namespace util

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -26,207 +26,128 @@
 // Internal Includes
 #include <osvr/Util/Logger.h>
 
+#include "LogLevelTranslate.h"
+
 // Library/third-party includes
 #include <spdlog/spdlog.h>
 
 // Standard includes
-#include <memory>           // for std::shared_ptr
-#include <utility>          // for std::forward
-#include <string>           // for std::string
+#include <memory>  // for std::shared_ptr
+#include <string>  // for std::string
+#include <utility> // for std::forward
 
 namespace osvr {
 namespace util {
-namespace log {
+    namespace log {
 
-Logger::Logger(const std::string& logger_name)
-{
-    logger_ = spdlog::get(logger_name);
-}
+        LoggerPtr Logger::getFromSpdlogByName(const std::string &logger_name) {
+            return std::make_shared<Logger>(spdlog::get(logger_name));
+        }
 
-Logger::Logger(std::shared_ptr<spdlog::logger> logger) : logger_(logger)
-{
-    // do nothing
-}
+        Logger::Logger(std::shared_ptr<spdlog::logger> logger)
+            : logger_(logger) {}
 
-Logger::~Logger()
-{
-    // FIXME
-}
+        LogLevel Logger::getLogLevel() const {
+            return convertFromLevelEnum(logger_->level());
+        }
 
-/*
-Logger::Logger(spdlog::logger* logger) : logger_(logger)
-{
-    // do nothing
-}
-*/
+        void Logger::setLogLevel(LogLevel level) {
+            logger_->set_level(convertToLevelEnum(level));
+        }
 
-LogLevel Logger::getLogLevel() const
-{
-    return static_cast<LogLevel>(logger_->level());
-}
+        void Logger::flushOn(LogLevel level) {
+            logger_->flush_on(convertToLevelEnum(level));
+        }
 
-void Logger::setLogLevel(LogLevel level)
-{
-    logger_->set_level(static_cast<spdlog::level::level_enum>(level));
-}
+        detail::LineLogger Logger::trace(const char *fmt) {
+            return logger_->trace(fmt);
+        }
 
-void Logger::flushOn(LogLevel level)
-{
-    logger_->flush_on(static_cast<spdlog::level::level_enum>(level));
-}
+        detail::LineLogger Logger::debug(const char *fmt) {
+            return logger_->debug(fmt);
+        }
 
-detail::LineLogger Logger::trace(const char* fmt)
-{
-    return logger_->trace(fmt);
-}
+        detail::LineLogger Logger::info(const char *fmt) {
+            return logger_->info(fmt);
+        }
 
-detail::LineLogger Logger::debug(const char* fmt)
-{
-    return logger_->debug(fmt);
-}
+        detail::LineLogger Logger::notice(const char *fmt) {
+            return logger_->notice(fmt);
+        }
 
-detail::LineLogger Logger::info(const char* fmt)
-{
-    return logger_->info(fmt);
-}
+        detail::LineLogger Logger::warn(const char *fmt) {
+            return logger_->warn(fmt);
+        }
 
-detail::LineLogger Logger::notice(const char* fmt)
-{
-    return logger_->notice(fmt);
-}
+        detail::LineLogger Logger::error(const char *fmt) {
+            return logger_->error(fmt);
+        }
 
-detail::LineLogger Logger::warn(const char* fmt)
-{
-    return logger_->warn(fmt);
-}
+        detail::LineLogger Logger::critical(const char *fmt) {
+            return logger_->critical(fmt);
+        }
 
-detail::LineLogger Logger::error(const char* fmt)
-{
-    return logger_->error(fmt);
-}
+        // logger.info() << ".." call  style
+        detail::LineLogger Logger::trace() { return logger_->trace(); }
 
-detail::LineLogger Logger::critical(const char* fmt)
-{
-    return logger_->critical(fmt);
-}
+        detail::LineLogger Logger::debug() { return logger_->debug(); }
 
-detail::LineLogger Logger::alert(const char* fmt)
-{
-    return logger_->alert(fmt);
-}
+        detail::LineLogger Logger::info() { return logger_->info(); }
 
-detail::LineLogger Logger::emerg(const char* fmt)
-{
-    return logger_->emerg(fmt);
-}
+        detail::LineLogger Logger::notice() { return logger_->notice(); }
 
+        detail::LineLogger Logger::warn() { return logger_->warn(); }
 
-// logger.info() << ".." call  style
-detail::LineLogger Logger::trace()
-{
-    return logger_->trace();
-}
+        detail::LineLogger Logger::error() { return logger_->error(); }
 
-detail::LineLogger Logger::debug()
-{
-    return logger_->debug();
-}
+        detail::LineLogger Logger::critical() { return logger_->critical(); }
 
-detail::LineLogger Logger::info()
-{
-    return logger_->info();
-}
+        // logger.log(log_level, msg) << ".." call style
+        detail::LineLogger Logger::log(LogLevel level, const char *msg) {
+            switch (level) {
+            case LogLevel::trace:
+                return trace(msg);
+            case LogLevel::debug:
+                return debug(msg);
+            case LogLevel::info:
+                return info(msg);
+            case LogLevel::notice:
+                return notice(msg);
+            case LogLevel::warn:
+                return warn(msg);
+            case LogLevel::err:
+                return error(msg);
+            case LogLevel::critical:
+                return critical(msg);
+            }
 
-detail::LineLogger Logger::notice()
-{
-    return logger_->notice();
-}
+            return info(msg);
+        }
 
-detail::LineLogger Logger::warn()
-{
-    return logger_->warn();
-}
+        // logger.log(log_level) << ".." call  style
+        detail::LineLogger Logger::log(LogLevel level) {
+            switch (level) {
+            case LogLevel::trace:
+                return trace();
+            case LogLevel::debug:
+                return debug();
+            case LogLevel::info:
+                return info();
+            case LogLevel::notice:
+                return notice();
+            case LogLevel::warn:
+                return warn();
+            case LogLevel::err:
+                return error();
+            case LogLevel::critical:
+                return critical();
+            }
 
-detail::LineLogger Logger::error()
-{
-    return logger_->error();
-}
+            return info();
+        }
 
-detail::LineLogger Logger::critical()
-{
-    return logger_->critical();
-}
+        void Logger::flush() { logger_->flush(); }
 
-detail::LineLogger Logger::alert()
-{
-    return logger_->alert();
-}
-
-detail::LineLogger Logger::emerg()
-{
-    return logger_->emerg();
-}
-
-// logger.log(log_level, msg) << ".." call style
-detail::LineLogger Logger::log(LogLevel level, const char* msg)
-{
-    switch (level) {
-    case LogLevel::trace:
-        return trace(msg);
-    case LogLevel::debug:
-        return debug(msg);
-    case LogLevel::info:
-        return info(msg);
-    case LogLevel::notice:
-        return notice(msg);
-    case LogLevel::warn:
-        return warn(msg);
-    case LogLevel::err:
-        return error(msg);
-    case LogLevel::critical:
-        return critical(msg);
-    case LogLevel::alert:
-        return alert(msg);
-    case LogLevel::emerg:
-        return emerg(msg);
-    }
-
-    return info(msg);
-}
-
-// logger.log(log_level) << ".." call  style
-detail::LineLogger Logger::log(LogLevel level)
-{
-    switch (level) {
-    case LogLevel::trace:
-        return trace();
-    case LogLevel::debug:
-        return debug();
-    case LogLevel::info:
-        return info();
-    case LogLevel::notice:
-        return notice();
-    case LogLevel::warn:
-        return warn();
-    case LogLevel::err:
-        return error();
-    case LogLevel::critical:
-        return critical();
-    case LogLevel::alert:
-        return alert();
-    case LogLevel::emerg:
-        return emerg();
-    }
-
-    return info();
-}
-
-void Logger::flush()
-{
-    logger_->flush();
-}
-
-} // end namespace log
-} // end namespace util
-} // end namespace osvr
-
+    } // namespace log
+} // namespace util
+} // namespace osvr

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -115,7 +115,7 @@ namespace util {
                 return notice(msg);
             case LogLevel::warn:
                 return warn(msg);
-            case LogLevel::err:
+            case LogLevel::error:
                 return error(msg);
             case LogLevel::critical:
                 return critical(msg);
@@ -137,7 +137,7 @@ namespace util {
                 return notice();
             case LogLevel::warn:
                 return warn();
-            case LogLevel::err:
+            case LogLevel::error:
                 return error();
             case LogLevel::critical:
                 return critical();

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -70,7 +70,7 @@ void Logger::setLogLevel(LogLevel level)
     logger_->set_level(static_cast<spdlog::level::level_enum>(level));
 }
 
-void Logger::flush_on(LogLevel level)
+void Logger::flushOn(LogLevel level)
 {
     logger_->flush_on(static_cast<spdlog::level::level_enum>(level));
 }

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -43,11 +43,6 @@ Logger::Logger(const std::string& logger_name)
     logger_ = spdlog::get(logger_name);
 }
 
-Logger::Logger(spdlog::logger* logger) : logger_(logger)
-{
-    // do nothing
-}
-
 Logger::Logger(std::shared_ptr<spdlog::logger> logger) : logger_(logger)
 {
     // do nothing

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -75,7 +75,7 @@ void Logger::setLogLevel(LogLevel level)
     logger_->set_level(static_cast<spdlog::level::level_enum>(level));
 }
 
-void flush_on(LogLevel level)
+void Logger::flush_on(LogLevel level)
 {
     logger_->flush_on(static_cast<spdlog::level::level_enum>(level));
 }

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -1,0 +1,389 @@
+/** @file
+    @brief Implementation
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com>
+
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Util/Logger.h>
+
+// Library/third-party includes
+#include <spdlog/spdlog.h>
+
+// Standard includes
+#include <memory>           // for std::shared_ptr
+#include <utility>          // for std::forward
+#include <string>           // for std::string
+
+namespace osvr {
+namespace util {
+namespace log {
+
+Logger::Logger(const std::string& logger_name)
+{
+    logger_ = spdlog::get(logger_name);
+}
+
+Logger::Logger(spdlog::logger* logger) : logger_(logger)
+{
+    // do nothing
+}
+
+Logger::Logger(std::shared_ptr<spdlog::logger> logger) : logger_(logger)
+{
+    // do nothing
+}
+
+Logger::~Logger()
+{
+    // FIXME
+}
+
+/*
+Logger::Logger(spdlog::logger* logger) : logger_(logger)
+{
+    // do nothing
+}
+*/
+
+LogLevel Logger::getLogLevel() const
+{
+    return static_cast<LogLevel>(logger_->level());
+}
+
+void Logger::setLogLevel(LogLevel level)
+{
+    logger_->set_level(static_cast<spdlog::level::level_enum>(level));
+}
+
+// Logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
+/*
+template <typename... Args> detail::LineLogger Logger::trace(const char* fmt, Args&&... args)
+{
+    return logger_->trace(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::debug(const char* fmt, Args&&... args)
+{
+    return logger_->debug(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::info(const char* fmt, Args&&... args)
+{
+    return logger_->info(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::notice(const char* fmt, Args&&... args)
+{
+    return logger_->notice(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::warn(const char* fmt, Args&&... args)
+{
+    return logger_->warn(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::error(const char* fmt, Args&&... args)
+{
+    return logger_->error(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::critical(const char* fmt, Args&&... args)
+{
+    return logger_->critical(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::alert(const char* fmt, Args&&... args)
+{
+    return logger_->alert(fmt, std::forward<Args>(args)...);
+}
+
+template <typename... Args> detail::LineLogger Logger::emerg(const char* fmt, Args&&... args)
+{
+    return logger_->emerg(fmt, std::forward<Args>(args)...);
+}
+*/
+
+detail::LineLogger Logger::trace(const char* fmt)
+{
+    return logger_->trace(fmt);
+}
+
+detail::LineLogger Logger::debug(const char* fmt)
+{
+    return logger_->debug(fmt);
+}
+
+detail::LineLogger Logger::info(const char* fmt)
+{
+    return logger_->info(fmt);
+}
+
+detail::LineLogger Logger::notice(const char* fmt)
+{
+    return logger_->notice(fmt);
+}
+
+detail::LineLogger Logger::warn(const char* fmt)
+{
+    return logger_->warn(fmt);
+}
+
+detail::LineLogger Logger::error(const char* fmt)
+{
+    return logger_->error(fmt);
+}
+
+detail::LineLogger Logger::critical(const char* fmt)
+{
+    return logger_->critical(fmt);
+}
+
+detail::LineLogger Logger::alert(const char* fmt)
+{
+    return logger_->alert(fmt);
+}
+
+detail::LineLogger Logger::emerg(const char* fmt)
+{
+    return logger_->emerg(fmt);
+}
+
+// logger.info(msg) << ".." call style
+template <typename T> detail::LineLogger Logger::trace(T&& msg)
+{
+    return logger_->trace(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::debug(T&& msg)
+{
+    return logger_->debug(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::info(T&& msg)
+{
+    return logger_->info(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::notice(T&& msg)
+{
+    return logger_->notice(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::warn(T&& msg)
+{
+    return logger_->warn(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::error(T&& msg)
+{
+    return logger_->error(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::critical(T&& msg)
+{
+    return logger_->critical(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::alert(T&& msg)
+{
+    return logger_->alert(std::forward<T>(msg));
+}
+
+template <typename T> detail::LineLogger Logger::emerg(T&& msg)
+{
+    return logger_->emerg(std::forward<T>(msg));
+}
+
+
+
+// logger.info() << ".." call  style
+detail::LineLogger Logger::trace()
+{
+    return logger_->trace();
+}
+
+detail::LineLogger Logger::debug()
+{
+    return logger_->debug();
+}
+
+detail::LineLogger Logger::info()
+{
+    return logger_->info();
+}
+
+detail::LineLogger Logger::notice()
+{
+    return logger_->notice();
+}
+
+detail::LineLogger Logger::warn()
+{
+    return logger_->warn();
+}
+
+detail::LineLogger Logger::error()
+{
+    return logger_->error();
+}
+
+detail::LineLogger Logger::critical()
+{
+    return logger_->critical();
+}
+
+detail::LineLogger Logger::alert()
+{
+    return logger_->alert();
+}
+
+detail::LineLogger Logger::emerg()
+{
+    return logger_->emerg();
+}
+
+// Logger.log(log_level, cppformat_string, arg1, arg2, arg3, ...) call style
+template <typename... Args>
+detail::LineLogger Logger::log(LogLevel level, const char* fmt, Args&&... args)
+{
+    switch (level) {
+    case LogLevel::trace:
+        return trace(fmt, std::forward<Args>(args)...);
+    case LogLevel::debug:
+        return debug(fmt, std::forward<Args>(args)...);
+    case LogLevel::info:
+        return info(fmt, std::forward<Args>(args)...);
+    case LogLevel::notice:
+        return notice(fmt, std::forward<Args>(args)...);
+    case LogLevel::warn:
+        return warn(fmt, std::forward<Args>(args)...);
+    case LogLevel::err:
+        return error(fmt, std::forward<Args>(args)...);
+    case LogLevel::critical:
+        return critical(fmt, std::forward<Args>(args)...);
+    case LogLevel::alert:
+        return alert(fmt, std::forward<Args>(args)...);
+    case LogLevel::emerg:
+        return emerg(fmt, std::forward<Args>(args)...);
+    }
+}
+
+// logger.log(log_level, msg) << ".." call style
+detail::LineLogger Logger::log(LogLevel level, const char* msg)
+{
+    switch (level) {
+    case LogLevel::trace:
+        return trace(msg);
+    case LogLevel::debug:
+        return debug(msg);
+    case LogLevel::info:
+        return info(msg);
+    case LogLevel::notice:
+        return notice(msg);
+    case LogLevel::warn:
+        return warn(msg);
+    case LogLevel::err:
+        return error(msg);
+    case LogLevel::critical:
+        return critical(msg);
+    case LogLevel::alert:
+        return alert(msg);
+    case LogLevel::emerg:
+        return emerg(msg);
+    }
+
+    return info(msg);
+}
+
+// logger.log(log_level, msg) << ".." call style
+template <typename T>
+detail::LineLogger Logger::log(LogLevel level, T&& msg)
+{
+    switch (level) {
+    case LogLevel::trace:
+        return trace(std::forward<T>(msg));
+    case LogLevel::debug:
+        return debug(std::forward<T>(msg));
+    case LogLevel::info:
+        return info(std::forward<T>(msg));
+    case LogLevel::notice:
+        return notice(std::forward<T>(msg));
+    case LogLevel::warn:
+        return warn(std::forward<T>(msg));
+    case LogLevel::err:
+        return error(std::forward<T>(msg));
+    case LogLevel::critical:
+        return critical(std::forward<T>(msg));
+    case LogLevel::alert:
+        return alert(std::forward<T>(msg));
+    case LogLevel::emerg:
+        return emerg(std::forward<T>(msg));
+    }
+
+    return info(std::forward<T>(msg));
+}
+
+// logger.log(log_level) << ".." call  style
+detail::LineLogger Logger::log(LogLevel level)
+{
+    switch (level) {
+    case LogLevel::trace:
+        return trace();
+    case LogLevel::debug:
+        return debug();
+    case LogLevel::info:
+        return info();
+    case LogLevel::notice:
+        return notice();
+    case LogLevel::warn:
+        return warn();
+    case LogLevel::err:
+        return error();
+    case LogLevel::critical:
+        return critical();
+    case LogLevel::alert:
+        return alert();
+    case LogLevel::emerg:
+        return emerg();
+    }
+
+    return info();
+}
+
+template <typename... Args>
+detail::LineLogger Logger::force_log(LogLevel level, const char* fmt, Args&&... args)
+{
+    auto lvl = static_cast<spdlog::level::level_enum>(level);
+    return logger_->force_log(lvl, fmt, std::forward<Args>(args)...);
+}
+
+void Logger::flush()
+{
+    logger_->flush();
+}
+
+
+} // end namespace log
+} // end namespace util
+} // end namespace osvr
+

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -56,24 +56,28 @@ namespace util {
         LoggerPtr Logger::makeWithSink(std::string const &name,
                                        spdlog::sink_ptr sink) {
             if (!sink) {
-				// bad sink!
+                // bad sink!
                 return LoggerPtr();
             }
-            auto spdlogPtr = std::make_shared<spdlog::logger>(name, sink);
-            return std::make_shared<Logger>(spdlogPtr);
+            auto spd_logger = std::make_shared<spdlog::logger>(name, sink);
+            spd_logger->set_pattern(DEFAULT_PATTERN);
+            spd_logger->flush_on(convertToLevelEnum(DEFAULT_FLUSH_LEVEL));
+            return std::make_shared<Logger>(spd_logger);
         }
 
         LoggerPtr Logger::makeWithSinks(std::string const &name,
                                         spdlog::sinks_init_list sinks) {
-            for (auto & sink : sinks) {
-				if (!sink) {
-					// got a bad sink
-					return LoggerPtr();
-				}
-			}
-            auto spdlogPtr = std::make_shared<spdlog::logger>(name, sinks);
-            return std::make_shared<Logger>(spdlogPtr);
-		}
+            for (auto &sink : sinks) {
+                if (!sink) {
+                    // got a bad sink
+                    return LoggerPtr();
+                }
+            }
+            auto spd_logger = std::make_shared<spdlog::logger>(name, sinks);
+            spd_logger->set_pattern(DEFAULT_PATTERN);
+            spd_logger->flush_on(convertToLevelEnum(DEFAULT_FLUSH_LEVEL));
+            return std::make_shared<Logger>(spd_logger);
+        }
 
         LogLevel Logger::getLogLevel() const {
             return convertFromLevelEnum(logger_->level());

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -26,6 +26,7 @@
 // Internal Includes
 #include <osvr/Util/Logger.h>
 
+#include "LogDefaults.h"
 #include "LogLevelTranslate.h"
 
 // Library/third-party includes
@@ -39,13 +40,40 @@
 namespace osvr {
 namespace util {
     namespace log {
-
+#if 0
         LoggerPtr Logger::getFromSpdlogByName(const std::string &logger_name) {
-            return std::make_shared<Logger>(spdlog::get(logger_name));
+			auto spdlogPtr = spdlog::get(logger_name);
+			if (!spdlogPtr) {
+				return LoggerPtr();
+			}
+            return std::make_shared<Logger>(spdlogPtr);
         }
+#endif
 
         Logger::Logger(std::shared_ptr<spdlog::logger> logger)
             : logger_(logger) {}
+
+        LoggerPtr Logger::makeWithSink(std::string const &name,
+                                       spdlog::sink_ptr sink) {
+            if (!sink) {
+				// bad sink!
+                return LoggerPtr();
+            }
+            auto spdlogPtr = std::make_shared<spdlog::logger>(name, sink);
+            return std::make_shared<Logger>(spdlogPtr);
+        }
+
+        LoggerPtr Logger::makeWithSinks(std::string const &name,
+                                        spdlog::sinks_init_list sinks) {
+            for (auto & sink : sinks) {
+				if (!sink) {
+					// got a bad sink
+					return LoggerPtr();
+				}
+			}
+            auto spdlogPtr = std::make_shared<spdlog::logger>(name, sinks);
+            return std::make_shared<Logger>(spdlogPtr);
+		}
 
         LogLevel Logger::getLogLevel() const {
             return convertFromLevelEnum(logger_->level());

--- a/src/osvr/Util/Logger.cpp
+++ b/src/osvr/Util/Logger.cpp
@@ -75,6 +75,11 @@ void Logger::setLogLevel(LogLevel level)
     logger_->set_level(static_cast<spdlog::level::level_enum>(level));
 }
 
+void flush_on(LogLevel level)
+{
+    logger_->flush_on(static_cast<spdlog::level::level_enum>(level));
+}
+
 detail::LineLogger Logger::trace(const char* fmt)
 {
     return logger_->trace(fmt);

--- a/src/osvr/Util/Verbosity.h.in
+++ b/src/osvr/Util/Verbosity.h.in
@@ -29,6 +29,7 @@
 #define INCLUDED_Verbosity_h_GUID_92D43527_D3AC_4BB4_FA39_91252412C1FF
 
 #include <osvr/Util/MacroToolsC.h>
+#include <osvr/Util/Log.h>
 
 #cmakedefine OSVR_UTIL_DEV_VERBOSE
 
@@ -41,8 +42,7 @@
 
 #include <iostream>
 #define OSVR_DEV_VERBOSE(X)                                                    \
-    OSVR_UTIL_MULTILINE_BEGIN std::cerr << "[OSVR] " << X << std::endl;        \
-    OSVR_UTIL_MULTILINE_END
+    OSVR_UTIL_MULTILINE_BEGIN OSVR_TRACE(X) OSVR_UTIL_MULTILINE_END
 
 #else
 

--- a/src/osvr/Util/Verbosity.h.in
+++ b/src/osvr/Util/Verbosity.h.in
@@ -29,7 +29,6 @@
 #define INCLUDED_Verbosity_h_GUID_92D43527_D3AC_4BB4_FA39_91252412C1FF
 
 #include <osvr/Util/MacroToolsC.h>
-#include <osvr/Util/Log.h>
 
 #cmakedefine OSVR_UTIL_DEV_VERBOSE
 
@@ -40,14 +39,27 @@
 
 #if defined(OSVR_UTIL_DEV_VERBOSE) && !defined(OSVR_DEV_VERBOSE_DISABLE)
 
-#include <iostream>
-#define OSVR_DEV_VERBOSE(X)                                                    \
-    OSVR_UTIL_MULTILINE_BEGIN OSVR_TRACE(X) OSVR_UTIL_MULTILINE_END
+#include <osvr/Util/Log.h>
+
+#define OSVR_TRACE(...)                                                        \
+    OSVR_UTIL_MULTILINE_BEGIN::osvr::util::log::make_logger("OSVR")->trace()   \
+        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;                 \
+    OSVR_UTIL_MULTILINE_END
+#define OSVR_DEBUG(...)                                                        \
+    OSVR_UTIL_MULTILINE_BEGIN::osvr::util::log::make_logger("OSVR")->debug()   \
+        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;                 \
+    OSVR_UTIL_MULTILINE_END
+#define OSVR_DEV_VERBOSE(...)                                                  \
+    OSVR_UTIL_MULTILINE_BEGIN::osvr::util::log::make_logger("OSVR")->info()    \
+        << __FILE__ << ":" << __LINE__ << ": " << __VA_ARGS__;                 \
+    OSVR_UTIL_MULTILINE_END
 
 #else
 
-#define OSVR_DEV_VERBOSE(X) OSVR_UTIL_MULTILINE_BEGIN OSVR_UTIL_MULTILINE_END
+#define OSVR_TRACE(...) OSVR_UTIL_MULTILINE_BEGIN OSVR_UTIL_MULTILINE_END
+#define OSVR_DEBUG(...) OSVR_UTIL_MULTILINE_BEGIN OSVR_UTIL_MULTILINE_END
+#define OSVR_DEV_VERBOSE(...) OSVR_UTIL_MULTILINE_BEGIN OSVR_UTIL_MULTILINE_END
 
-#endif
+#endif // OSVR_UTIL_DEV_VERBOSE && !OSVR_DEV_VERBOSE_DISABLE
 
 #endif // INCLUDED_Verbosity_h_GUID_92D43527_D3AC_4BB4_FA39_91252412C1FF

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LIBRARIES_PluginKit libfunctionality::functionality)
 set(LIBRARIES_VRPNServer libfunctionality::functionality)
 set(LIBRARIES_TypePack osvrTypePack)
 
-set(COMMON_TEST_LIBRARIES eigen-headers vendored-vrpn)
+set(COMMON_TEST_LIBRARIES eigen-headers vendored-vrpn spdlog)
 if(TARGET JsonCpp::JsonCpp)
     list(APPEND COMMON_TEST_LIBRARIES JsonCpp::JsonCpp)
 endif()

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,3 +1,10 @@
+
+# Interface target for spdlog
+add_library(spdlog INTERFACE)
+set(OSVR_VENDORED_SPDLOG_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/spdlog" CACHE INTERNAL "" FORCE)
+target_include_directories(spdlog INTERFACE "${OSVR_VENDORED_SPDLOG_ROOT}/include")
+#target_compile_definitions(spdlog INTERFACE SPDLOG_DEFINITIONS)
+
 if(BUILD_TESTING)
     if(WIN32)
         set(gtest_force_shared_crt ON)


### PR DESCRIPTION
This PR addresses issue #41 by providing a logging system that can be used internally by OSVR libraries and externally by OSVR clients and plugins. It logs both to the console and to a log file.

## Logging from within OSVR libraries

Internally, you have full access to the C++ Logger interface:
```c++
#include <osvr/Util/Log.h>

auto logger = osvr::util::log::make_logger("RenderManager");
logger->error() << "Hello, " << "world!"; // stream operator
```

## Logging from an OSVR client
A more limited interface is provided for clients:
```c++
// C API
#include <osvr/ClientKit/ContextC.h>

// C++ API
#include <osvr/ClientKit/Context.h>

int main() {
    // C API
    OSVR_ClientContext ctx = osvrClientInit("com.osvr.example.client", 0);
    osvrClientLog(ctx, OSVR_LOGLEVEL_NOTICE, "Hello, world!");

    // C++ API
    osvr::clientkit::ClientContext context("com.osvr.example.client");
    context.log(OSVR_LOGLEVEL_EMERG, "Goodbye, cruel world!");
}
```

## Logging from an OSVR plugin

A similar interface is provided for plugins:

```c++
#include <osvr/PluginKit/PluginKitC.h>
// ... or ...
#include <osvr/PluginKit/PluginKit.h>

OSVR_PLUGIN(org_osvr_example_plugin)
{
    // C API
    osvrPluginLog(ctx, OSVR_LOGLEVEL_INFO, "Plugin loaded.");

    // C++ PluginKit
    osvr::pluginkit::PluginContext context{ctx};
    context.log(OSVR_LOGLEVEL_TRACE, "Plugin loaded.");

    // ...

    return OSVR_RETURN_SUCCESS;
}
```

## Log file locations

The log files are stored in platform-sensitive locations:

  * Windows: `%LocalAppData%\OSVR\Logs\`
  * Linux: `$XDG_CACHE_HOME/osvr/logs` or `$HOME/.cache/osvr/logs`
  * OS X: `$HOME/Library/Logs/OSVR`

## Future plans

These are items on my to do list that aren't in this pull request (primarily because I want to merge before I venture any further away from the master branch).

- [ ] Allow log files location to be overridden with environment variable or API call.
- [ ] Modify `osvr_server` to allow for various logging parameters to be set (e.g., log file location, disable/enable console output, set log verbosity/severity levels).
- [ ] Evaluate existing uses of the `OSVR_DEV_VERBOSE()` macro and convert them to the new logging system.
- [ ] Add color console output to Windows.
- [ ] Explore adding sinks for game engine IDEs (e.g., Unreal, Unity).
- [x] Implement and test logging on Android. (An Android sink exists, but I haven't tied it in yet.)