### PR TITLE
Adding client-side prediction entries to the DirectMode and non-Direc…

### DIFF
--- a/apps/sample-configs/renderManager.direct.landscape.json
+++ b/apps/sample-configs/renderManager.direct.landscape.json
@@ -23,6 +23,14 @@
             "bitsPerColor": 8
         },
 
+		"prediction": {
+				"enabled": true,
+				"staticDelayMS": 32,
+				"leftEyeDelayMS": 7.5,
+				"rightEyeDelayMS": 0,
+				"localTimeOverride": true
+		},
+
         "timeWarp": {
             "enabled": true,
             "asynchronous": false,

--- a/apps/sample-configs/renderManager.direct.portrait.json
+++ b/apps/sample-configs/renderManager.direct.portrait.json
@@ -23,6 +23,14 @@
             "bitsPerColor": 8
         },
 
+		"prediction": {
+				"enabled": true,
+				"staticDelayMS": 16,
+				"leftEyeDelayMS": 7.5,
+				"rightEyeDelayMS": 0,
+				"localTimeOverride": true
+		},
+
         "timeWarp": {
             "enabled": true,
             "asynchronous": false,

--- a/apps/sample-configs/renderManager.extended.landscape.json
+++ b/apps/sample-configs/renderManager.extended.landscape.json
@@ -23,6 +23,14 @@
             "bitsPerColor": 8
         },
 
+		"prediction": {
+				"enabled": true,
+				"staticDelayMS": 48,
+				"leftEyeDelayMS": 7.5,
+				"rightEyeDelayMS": 0,
+				"localTimeOverride": true
+		},
+
         "timeWarp": {
             "enabled": true,
             "asynchronous": false,

--- a/apps/sample-configs/renderManager.extended.portrait.json
+++ b/apps/sample-configs/renderManager.extended.portrait.json
@@ -23,6 +23,14 @@
             "bitsPerColor": 8
         },
 
+		"prediction": {
+				"enabled": true,
+				"staticDelayMS": 32,
+				"leftEyeDelayMS": 7.5,
+				"rightEyeDelayMS": 0,
+				"localTimeOverride": true
+		},
+
         "timeWarp": {
             "enabled": true,
             "asynchronous": false,


### PR DESCRIPTION
…tMode RenderManager configs assuming that they are being applied to an HDK.

Varies the prediction interval for landscape/portait and direct/nondirect.
Adds expected HDK sensor delay to all of them.