### PR TITLE
Generate the location to install configs to into the CMake config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,14 @@ endif()
 set(EXTRA_SAMPLE_BINDIR ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/extra-sample-apps)
 if(WIN32)
     # On Windows, install sample configs, etc. to a subdirectory of bin.
-    set(SAMPLE_CONFIGS_DIR "${CMAKE_INSTALL_BINDIR}")
+    set(OSVR_CONFIG_ROOT "${CMAKE_INSTALL_BINDIR}")
+
+    # In a build tree, we use the generator expression to put it alongside the server.
+    set(OSVR_CACHED_CONFIG_ROOT "$<TARGET_FILE_DIR:osvr_server>" CACHE INTERNAL "")
 else()
-    set(SAMPLE_CONFIGS_DIR "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
+    set(OSVR_CONFIG_ROOT "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
+    # In build tree, put in similar location as we would in the install
+    set(OSVR_CACHED_CONFIG_ROOT "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}" CACHE INTERNAL "")
 endif()
 
 # Shared modules from rpavlik/cmake-modules

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -178,11 +178,10 @@ if(BUILD_SERVER_APP)
     endmacro()
 
     # Set up variables to begin the JSON copying
+    set(data_buildtree_dir "${OSVR_CACHED_CONFIG_ROOT}")
     if(WIN32)
-        set(data_buildtree_dir "$<TARGET_FILE_DIR:osvr_server>")
         set(DEFAULT_CONFIG_EXTRA_ARGS)
     else()
-        set(data_buildtree_dir "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
         # Here, we need to create the directory to copy to.
         add_custom_command(OUTPUT "data_buildtree_dir-stamp"
             COMMAND "${CMAKE_COMMAND}" -E make_directory "${data_buildtree_dir}"
@@ -190,7 +189,7 @@ if(BUILD_SERVER_APP)
         set_source_files_properties("data_buildtree_dir-stamp" PROPERTIES SYMBOLIC TRUE)
         set(DEFAULT_CONFIG_EXTRA_ARGS DEPENDS "data_buildtree_dir-stamp")
     endif()
-    set(data_installtree_dir ${SAMPLE_CONFIGS_DIR})
+    set(data_installtree_dir ${OSVR_CONFIG_ROOT})
     set(FILE_OUTPUTS)
 
     # Macro to easily copy for build and install a single file.
@@ -232,10 +231,10 @@ if(BUILD_SERVER_APP)
     endif()
 
     # Copy/install subdirectories of JSON files
-    osvr_copy_dir(displays *.json ${data_buildtree_dir} ${SAMPLE_CONFIGS_DIR} "JSON display descriptor")
-    osvr_copy_dir(sample-configs *.json ${data_buildtree_dir} ${SAMPLE_CONFIGS_DIR} "sample OSVR Server config")
-    osvr_copy_dir(external-devices *.json ${data_buildtree_dir} ${SAMPLE_CONFIGS_DIR} "OSVR Server Configs for External VRPN devices")
-    osvr_copy_dir(external-devices/device-descriptors *.json ${data_buildtree_dir} ${SAMPLE_CONFIGS_DIR} "Device Descriptors for External VRPN devices")
+    osvr_copy_dir(displays *.json ${data_buildtree_dir} ${OSVR_CONFIG_ROOT} "JSON display descriptor")
+    osvr_copy_dir(sample-configs *.json ${data_buildtree_dir} ${OSVR_CONFIG_ROOT} "sample OSVR Server config")
+    osvr_copy_dir(external-devices *.json ${data_buildtree_dir} ${OSVR_CONFIG_ROOT} "OSVR Server Configs for External VRPN devices")
+    osvr_copy_dir(external-devices/device-descriptors *.json ${data_buildtree_dir} ${OSVR_CONFIG_ROOT} "Device Descriptors for External VRPN devices")
 
     # Have to set them as symbolic because we can't use a generator expression in add_custom_command(OUTPUT
     set_source_files_properties(${FILE_OUTPUTS} PROPERTIES SYMBOLIC TRUE)

--- a/cmake-local/osvrConfig.cmake
+++ b/cmake-local/osvrConfig.cmake
@@ -23,6 +23,9 @@ set(OSVR_CACHED_PLUGIN_DIR "@OSVR_PLUGIN_DIR@" CACHE INTERNAL
 set(OSVR_PLUGIN_IGNORE_SUFFIX "@OSVR_PLUGIN_IGNORE_SUFFIX@" CACHE INTERNAL
     "The additional suffix for OSVR plugins that are not to be auto-loaded" FORCE)
 
+set(OSVR_CACHED_CONFIG_ROOT "@OSVR_CONFIG_ROOT@" CACHE INTERNAL
+    "The OSVR_CONFIG_ROOT variable for OSVR, for use in installing plugins' sample configs, display descriptors, etc." FORCE)
+
 # Hook for a super-build to optionally inject configuration after target import.
 include("${CMAKE_CURRENT_LIST_DIR}/osvrConfigSuperBuildSuffix.cmake" OPTIONAL)
 


### PR DESCRIPTION
This adds another cache variable to the generated cmake config file, so that plugins can know where to install configs and display descriptors.