### PR TITLE
Android autostart

### DIFF
--- a/cmake-local/osvrAddPlugin.cmake
+++ b/cmake-local/osvrAddPlugin.cmake
@@ -29,8 +29,14 @@ function(osvr_add_plugin)
         target_link_libraries(${OSVR_ADD_PLUGIN_NAME} osvr::osvrPluginKit)
     endif()
 
+    if(ANDROID)
+        set(OSVR_PLUGIN_PREFIX "lib")
+    else()
+        set(OSVR_PLUGIN_PREFIX "")
+    endif()
+    
     set_target_properties(${OSVR_ADD_PLUGIN_NAME} PROPERTIES
-        PREFIX ""
+        PREFIX "${OSVR_PLUGIN_PREFIX}"
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OSVR_CACHED_PLUGIN_DIR}"
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${OSVR_CACHED_PLUGIN_DIR}")
     if(OSVR_ADD_PLUGIN_MANUAL_LOAD)

--- a/src/osvr/ClientKit/CMakeLists.txt
+++ b/src/osvr/ClientKit/CMakeLists.txt
@@ -59,6 +59,12 @@ target_link_libraries(${LIBNAME_FULL}
     osvrCommon
     eigen-headers)
 
+if(ANDROID)
+    target_link_libraries(${LIBNAME_FULL}
+        PRIVATE
+        osvrServer)
+endif()
+        
 ###
 # C++ (header-only) interface
 ###

--- a/src/osvr/ClientKit/ServerAutoStartC.cpp
+++ b/src/osvr/ClientKit/ServerAutoStartC.cpp
@@ -28,7 +28,9 @@
 #include <osvr/Util/PlatformConfig.h>
 #include <osvr/Client/LocateServer.h>
 #include <osvr/Common/GetEnvironmentVariable.h>
+#if defined(OSVR_ANDROID)
 #include <osvr/Server/ConfigureServerFromFile.h>
+#endif
 
 // Library/third-party includes
 // - none
@@ -36,7 +38,9 @@
 // Standard includes
 // - none
 
+#if defined(OSVR_ANDROID)
 static osvr::server::ServerPtr gServer;
+#endif
 
 void osvrClientAttemptServerAutoStart()
 {

--- a/src/osvr/ClientKit/ServerAutoStartC.cpp
+++ b/src/osvr/ClientKit/ServerAutoStartC.cpp
@@ -28,6 +28,7 @@
 #include <osvr/Util/PlatformConfig.h>
 #include <osvr/Client/LocateServer.h>
 #include <osvr/Common/GetEnvironmentVariable.h>
+#include <osvr/Server/ConfigureServerFromFile.h>
 
 // Library/third-party includes
 // - none
@@ -35,11 +36,17 @@
 // Standard includes
 // - none
 
+static osvr::server::ServerPtr gServer;
+
 void osvrClientAttemptServerAutoStart()
 {
     // @todo start the server.
 #if defined(OSVR_ANDROID)
-    // @todo implement auto-start for android
+    if(!gServer) {
+        std::string configName(osvr::server::getDefaultConfigFilename());
+        gServer = osvr::server::configureServerFromFile(configName);
+        gServer->start();
+    }
 #else
     auto server = osvr::client::getServerBinaryDirectoryPath();
     if (server) {
@@ -64,7 +71,10 @@ void osvrClientAttemptServerAutoStart()
 void osvrClientReleaseAutoStartedServer()
 {
 #if defined(OSVR_ANDROID)
-    // @todo cleanup server thread
+    if(gServer) {
+        gServer->stop();
+        gServer = nullptr;
+    }
 #else
     // no-op. Leave the server running.
 #endif

--- a/src/osvr/ClientKit/ServerAutoStartC.cpp
+++ b/src/osvr/ClientKit/ServerAutoStartC.cpp
@@ -38,6 +38,7 @@
 // Standard includes
 // - none
 
+// @todo use a thread-safe lazy-initialized singleton pattern
 #if defined(OSVR_ANDROID)
 static osvr::server::ServerPtr gServer;
 #endif


### PR DESCRIPTION
This is an implementation of the auto-start API for Android. It requires linking osvrClientKit to osvrServer, but this is only done for the Android platform.

Requires this libfunctionality PR to be merged: https://github.com/OSVR/libfunctionality/pull/15