### PR TITLE
Thread-safety for device descriptor sending in async plugins.

### DIFF
--- a/src/osvr/Connection/DeviceToken.cpp
+++ b/src/osvr/Connection/DeviceToken.cpp
@@ -116,6 +116,8 @@ bool OSVR_DeviceTokenObject::releaseObject(void *obj) {
 
 void OSVR_DeviceTokenObject::setDeviceDescriptor(
     std::string const &jsonString) {
+    auto guard = getSendGuard();
+    guard->lock();
     m_getConnectionDevice()->setDeviceDescriptor(jsonString);
     m_getConnection()->triggerDescriptorHandlers();
 }


### PR DESCRIPTION
I think I hit this in early revisions of the vive plugin - it seems like the original implementation of the device descriptor sending code assumed you'd either only send it once, or you'd be a sync plugin and send from the main thread: there was no send-guard or equiv. locking around the descriptor update but that's definitely not something you want to do in a non-main thread since it can trigger a send.

This hasn't been tested, don't merge it until it has been.