### PR TITLE
Timer frequency

### DIFF
--- a/inc/osvr/Common/LowLatency.h
+++ b/inc/osvr/Common/LowLatency.h
@@ -1,0 +1,68 @@
+/** @file
+    @brief Header for an RAII object defining platform-specific actions to take
+   to enter/exit a "low-latency" system mode.
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_LowLatency_h_GUID_A7B15740_3824_499E_22C3_EE2B08AFC7AC
+#define INCLUDED_LowLatency_h_GUID_A7B15740_3824_499E_22C3_EE2B08AFC7AC
+
+// Internal Includes
+#include <osvr/Common/Export.h>
+
+// Library/third-party includes
+// - none
+
+// Standard includes
+#include <memory>
+
+namespace osvr {
+namespace common {
+    /// An object that sets a system for low-latency, but potentially
+    /// high-CPU-usage, high power, and even lower-performance due to scheduling
+    /// (see the cautions about timeBeginPeriod).
+    ///
+    /// Typical usage would be for a class to hold a unique_ptr of this,
+    /// instantiate a new one only when you need to enter the mode, then reset
+    /// the pointer when you don't need it any more.
+    ///
+    /// Explanation, by way of implementation detail: On Windows, this requests
+    /// a change to the Windows global timer frequency with timeBeginPeriod and
+    /// matching timeEndPeriod. Not polite to leave it on long-term, but "this
+    /// is VR" so when milliseconds count, it might be OK. Bruce Dawson even
+    /// says so :)
+    /// https://randomascii.wordpress.com/2016/03/08/power-wastage-on-an-idle-laptop/#comment-20184
+    class LowLatency {
+      public:
+        OSVR_COMMON_EXPORT LowLatency();
+        OSVR_COMMON_EXPORT ~LowLatency();
+        LowLatency(LowLatency const &) = delete;
+        LowLatency &operator=(LowLatency const &) = delete;
+
+      private:
+        // private implementation, if any is needed.
+        struct Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+} // namespace common
+} // namespace osvr
+#endif // INCLUDED_LowLatency_h_GUID_A7B15740_3824_499E_22C3_EE2B08AFC7AC

--- a/src/osvr/Common/CMakeLists.txt
+++ b/src/osvr/Common/CMakeLists.txt
@@ -77,6 +77,7 @@ set(API
     "${HEADER_LOCATION}/JSONTransformVisitor.h"
     "${HEADER_LOCATION}/Location2DComponent.h"
     "${HEADER_LOCATION}/LocomotionComponent.h"
+    "${HEADER_LOCATION}/LowLatency.h"
     "${HEADER_LOCATION}/MessageHandler.h"
     "${HEADER_LOCATION}/MessageRegistration.h"
     "${HEADER_LOCATION}/NetworkClassOfService.h"
@@ -150,6 +151,7 @@ set(SOURCE
     JSONTransformVisitor.cpp
     Location2DComponent.cpp
     LocomotionComponent.cpp
+    LowLatency.cpp
     MessageHandler.cpp
     MessageRegistration.cpp
     NetworkClassOfService.cpp

--- a/src/osvr/Common/LowLatency.cpp
+++ b/src/osvr/Common/LowLatency.cpp
@@ -1,0 +1,72 @@
+/** @file
+    @brief Implementation
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/Common/LowLatency.h>
+
+#ifdef _WIN32
+#define NO_MINMAX
+#include <windows.h>
+#endif
+
+namespace osvr {
+namespace common {
+
+#ifdef _WIN32
+#define OSVR_HAVE_LOWLATENCY_CODE
+    /// Drop timer period to 1ms when in low latency mode.
+    static const UINT TIMER_PERIOD = 1;
+    struct LowLatency::Impl {
+        bool beginSucceeded = false;
+    };
+
+/// @todo Unclear from docs whether a failed call to timeEndPeriod must also be
+/// matched
+/// https://msdn.microsoft.com/en-us/library/windows/desktop/dd757624(v=vs.85).aspx
+#if 0
+    LowLatency::LowLatency() : m_impl(new Impl) {
+        auto result = timeBeginPeriod(TIMER_PERIOD);
+        if (TIMERR_NOERROR == result) {
+            m_impl->beginSucceeded = true;
+        }
+    }
+#endif
+
+    LowLatency::LowLatency() { timeBeginPeriod(TIMER_PERIOD); }
+    LowLatency::~LowLatency() {
+        /// Don't really care about the success of this call - nothing we can
+        /// do.
+        timeEndPeriod(TIMER_PERIOD);
+    }
+#endif
+
+#ifndef OSVR_HAVE_LOWLATENCY_CODE
+    // Fallback no-op implementations
+    struct LowLatency::Impl {};
+    LowLatency::LowLatency() {}
+    ~LowLatency() {}
+#endif
+
+} // namespace common
+} // namespace osvr

--- a/src/osvr/Common/LowLatency.cpp
+++ b/src/osvr/Common/LowLatency.cpp
@@ -65,7 +65,7 @@ namespace common {
     // Fallback no-op implementations
     struct LowLatency::Impl {};
     LowLatency::LowLatency() {}
-    ~LowLatency() {}
+    LowLatency::~LowLatency() {}
 #endif
 
 } // namespace common

--- a/src/osvr/Server/ServerImpl.cpp
+++ b/src/osvr/Server/ServerImpl.cpp
@@ -390,6 +390,8 @@ namespace server {
             OSVR_DEV_VERBOSE("Got first client connection, exiting idle mode.");
             self->m_currentSleepTime = self->m_sleepTime;
         }
+        /// Create the low-latency behavior object.
+        self->m_lowLatency.reset(new common::LowLatency);
         return 0;
     }
 
@@ -403,6 +405,9 @@ namespace server {
                 "Dropped last client connection, entering idle mode.");
             self->m_currentSleepTime = IDLE_SLEEP_TIME;
         }
+
+        /// Destroy the low-latency behavior object
+        self->m_lowLatency.reset();
         return 0;
     }
 

--- a/src/osvr/Server/ServerImpl.h
+++ b/src/osvr/Server/ServerImpl.h
@@ -29,6 +29,7 @@
 #include <osvr/Server/Server.h>
 #include <osvr/Connection/ConnectionPtr.h>
 #include <osvr/Util/SharedPtr.h>
+#include <osvr/Util/UniquePtr.h>
 #include <osvr/PluginHost/RegistrationContext_fwd.h>
 #include <osvr/Connection/MessageTypePtr.h>
 #include <osvr/Connection/DeviceToken.h>
@@ -36,6 +37,7 @@
 #include <osvr/Common/SystemComponent_fwd.h>
 #include <osvr/Common/CommonComponent_fwd.h>
 #include <osvr/Common/PathTree.h>
+#include <osvr/Common/LowLatency.h>
 #include <osvr/Util/Flag.h>
 
 // Library/third-party includes
@@ -249,6 +251,9 @@ namespace server {
 
         /// The port we're listening on, if any.
         int m_port;
+
+        /// Latency reduction RAII object
+        unique_ptr<common::LowLatency> m_lowLatency;
     };
 
     /// @brief Class to temporarily (in RAII style) change a thread ID variable


### PR DESCRIPTION
Apps are probably bumping the timer frequency already, but in case they aren't, we don't want to accidentally miss milliseconds.  This patch adds an RAII class to increase/decrease the timer frequency, and hooks it up to the server idle mechanism (so we won't spin up the timer frequency if we're supposed to be idling).

 Even @randomascii says it's OK, because VR is a special case where you can see milliseconds :sweat_smile: https://randomascii.wordpress.com/2016/03/08/power-wastage-on-an-idle-laptop/#comment-20184