### PR TITLE
Work around missing move c'tor in some ostream implementations.

### DIFF
--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -127,7 +127,8 @@ namespace util {
                 class StreamProxy {
                   public:
                     StreamProxy(LineLogger &lineLogger)
-                        : lineLogger_(lineLogger) {}
+                        : lineLogger_(lineLogger), os_(new std::ostringstream) {
+                    }
 
                     /// destructor appends the finished stringstream at the end
                     /// of the expression.

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -128,13 +128,15 @@ namespace util {
                   public:
                     StreamProxy(LineLogger &lineLogger)
                         : lineLogger_(lineLogger) {}
+
                     /// destructor appends the finished stringstream at the end
                     /// of the expression.
                     ~StreamProxy() {
                         if (active_) {
-                            lineLogger_.append(os_.str());
+                            lineLogger_.append(os_->str());
                         }
                     }
+
                     /// move construction
                     StreamProxy(StreamProxy &&other)
                         : lineLogger_(other.lineLogger_),
@@ -145,15 +147,16 @@ namespace util {
                     StreamProxy(StreamProxy const &) = delete;
                     StreamProxy &operator=(StreamProxy const &) = delete;
 
-                    operator std::ostream &() { return os_; }
+                    operator std::ostream &() { return *os_.get(); }
+
                     template <typename T> std::ostream &operator<<(T &&what) {
-                        os_ << std::forward<T>(what);
-                        return os_;
+                        *os_.get() << std::forward<T>(what);
+                        return *os_.get();
                     }
 
                   private:
                     LineLogger &lineLogger_;
-                    std::ostringstream os_;
+                    std::unique_ptr<std::ostringstream> os_;
                     bool active_ = true;
                 };
 

--- a/inc/osvr/Util/LineLogger.h
+++ b/inc/osvr/Util/LineLogger.h
@@ -133,7 +133,7 @@ namespace util {
                     /// destructor appends the finished stringstream at the end
                     /// of the expression.
                     ~StreamProxy() {
-                        if (active_) {
+                        if (active_ && os_) {
                             lineLogger_.append(os_->str());
                         }
                     }
@@ -148,11 +148,11 @@ namespace util {
                     StreamProxy(StreamProxy const &) = delete;
                     StreamProxy &operator=(StreamProxy const &) = delete;
 
-                    operator std::ostream &() { return *os_.get(); }
+                    operator std::ostream &() { return (*os_); }
 
                     template <typename T> std::ostream &operator<<(T &&what) {
-                        *os_.get() << std::forward<T>(what);
-                        return *os_.get();
+                        (*os_) << std::forward<T>(what);
+                        return (*os_);
                     }
 
                   private:


### PR DESCRIPTION
This was fixed in GCC 5 (see [this bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54316)).
