### PR TITLE
Commit: 948259e3244d9e39387a2c0734cc990aa833469c breaks cmake-3.2.0 that used to works fine.

### DIFF
--- a/cmake/cmake-3.2.0-modules/FindGit.cmake
+++ b/cmake/cmake-3.2.0-modules/FindGit.cmake
@@ -100,7 +100,7 @@ endif()
 # Handle the QUIETLY and REQUIRED arguments and set GIT_FOUND to TRUE if
 # all listed variables are TRUE
 
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 find_package_handle_standard_args(Git
                                   REQUIRED_VARS GIT_EXECUTABLE
                                   VERSION_VAR GIT_VERSION_STRING)


### PR DESCRIPTION
There are two ways to solve this problem, copy the missing cmake modules or use this approach that is way simple.

Error:
    /tmp/osvr/OSVR-Core/cmake/cmake-3.2.0-modules/FindPackageHandleStandardArgs.cmake
Call Stack (most recent call first):
  cmake/GetGitRevisionDescription.cmake:85 (find_package)
  cmake/GetGitRevisionDescription.cmake:128 (git_describe)
  vendor/vrpn/ParseVersion.cmake:36 (git_get_exact_tag)
  vendor/vrpn/CMakeLists.txt:82 (include)