### PR TITLE
Ships .PDB files (debug symbols) for Debug and RelWithDebInfo configs…

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -26,6 +26,7 @@ if(BUILD_CLIENT_APPS)
         FOLDER "OSVR Stock Applications")
     install(TARGETS osvr_print_tree
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime)
+    osvr_install_symbols_for_target(osvr_print_tree)
 
     ###
     # osvr_dump_tree_json - NOT installed
@@ -153,6 +154,7 @@ if(BUILD_SERVER_APP)
         FOLDER "OSVR Stock Applications")
     install(TARGETS osvr_server
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime)
+    osvr_install_symbols_for_target(osvr_server)
 
     # Macro:
     # Copy contents of dir for both build and install trees - directories of JSON configs and descriptors

--- a/cmake-local/InstallDebugSymbols.cmake
+++ b/cmake-local/InstallDebugSymbols.cmake
@@ -1,0 +1,22 @@
+if(MSVC AND NOT CMAKE_VERSION VERSION_LESS 3.2)
+    function(osvr_install_symbols_for_target _target)
+        # debug symbols for MSVC: supported on CMake 3.2 and up where there's a
+        # generator expression for a target's PDB file
+        get_target_property(_target_type ${_target} TYPE)
+        if("${_target_type}" STREQUAL "EXECUTABLE" OR "${_target_type}" STREQUAL "SHARED_LIBRARY")
+            # exe or dll: put it alongside the runtime component
+            set(DEST ${CMAKE_INSTALL_BINDIR})
+        else()
+            set(DEST ${CMAKE_INSTALL_LIBDIR})
+        endif()
+        set(HAS_SYMBOLS_CONDITION $<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>)
+        install(FILES $<${HAS_SYMBOLS_CONDITION}:$<TARGET_PDB_FILE:${_target}>>
+            DESTINATION ${DEST}
+            COMPONENT Devel
+            ${ARGN})
+    endfunction()
+else()
+    function(osvr_install_symbols_for_target)
+        # do nothing if too old of CMake or not MSVC.
+    endfunction()
+endif()

--- a/src/osvr/Macros.cmake
+++ b/src/osvr/Macros.cmake
@@ -1,3 +1,5 @@
+include(InstallDebugSymbols)
+
 set(LIB_FOLDER "OSVR Libraries")
 
 set(OSVR_BUILDTREE_TARGETS "" CACHE INTERNAL "" FORCE)
@@ -71,6 +73,9 @@ macro(osvr_add_library)
         DESTINATION
         ${CMAKE_INSTALL_INCLUDEDIR}/osvr/${LIBNAME}
         COMPONENT Devel)
+
+    osvr_install_symbols_for_target(${LIBNAME_FULL})
+
     osvr_append_target(BUILDTREE ${LIBNAME_FULL})
 endmacro()
 


### PR DESCRIPTION
… built with MSVC.

Requires CMake 3.2 or newer, gracefully does nothing on older CMake versions.

For the build products that include this (core snapshots by default) or can be modified to (presumably at least the SDK installers), this will result in actually usable stack traces on developers' machines from centrally- or otherwise non-locally-built binaries.