### PR TITLE
Marking SDL2 as required because the library fails to build and link …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ endif()
 
 # Must be before MapImportedReleaseVariants
 find_package(OpenGL)
-find_package(SDL2)
+find_package(SDL2 REQUIRED)
 
 include(MapImportedReleaseVariants)
 include(EnableExtraCompilerWarnings)


### PR DESCRIPTION
…without it, at least on Visual Studio 2015 with OpenCV turned off.