### PR TITLE
Various logging updates

### DIFF
--- a/inc/osvr/Util/Log.h
+++ b/inc/osvr/Util/Log.h
@@ -75,13 +75,13 @@ namespace util {
         /// The logger will survive until the last copy of it is destroyed
         /// (e.g., goes out of scope). This function is useful if you want to
         /// destroy a logger before the program terminates.
-        void drop(const std::string &logger_name);
+        OSVR_UTIL_EXPORT void drop(const std::string &logger_name);
 
         /// @brief Removes all the registered loggers from the registry.
         ///
         /// Each logger will survive until the last copy of it is destroyed
         /// (e.g., goes out of scope).
-        void dropAll();
+        OSVR_UTIL_EXPORT void dropAll();
 
         /// @brief For implementations with a centralized logger registry, flush
         /// all logger sinks.

--- a/inc/osvr/Util/Log.h
+++ b/inc/osvr/Util/Log.h
@@ -70,6 +70,19 @@ namespace util {
         /// though it may be a "fallback" logger.
         OSVR_UTIL_EXPORT LoggerPtr make_logger(const std::string &logger_name);
 
+        /// @brief Drops a logger from the registry.
+        ///
+        /// The logger will survive until the last copy of it is destroyed
+        /// (e.g., goes out of scope). This function is useful if you want to
+        /// destroy a logger before the program terminates.
+        void drop(const std::string &logger_name);
+
+        /// @brief Removes all the registered loggers from the registry.
+        ///
+        /// Each logger will survive until the last copy of it is destroyed
+        /// (e.g., goes out of scope).
+        void dropAll();
+
         /// @brief For implementations with a centralized logger registry, flush
         /// all logger sinks.
         OSVR_UTIL_EXPORT void flush();

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -64,9 +64,37 @@ namespace util {
 
             static LogRegistry &instance(std::string const * = nullptr);
 
+            /**
+             * @brief Gets or creates a logger named @c logger_name.
+             *
+             * If the logger named @c logger_name already exists, return
+             * it, otherwise create a new logger of that name.
+             *
+             * @param logger_name The name of the logger.
+             *
+             */
             LoggerPtr getOrCreateLogger(const std::string &logger_name);
 
-            /// @brief Flush all sinks manually.
+            /**
+             * @brief Drops a logger from the registry.
+             *
+             * The logger will survive until the last copy of it is destroyed
+             * (e.g., goes out of scope). This function is useful if you want to
+             * destroy a logger before the program terminates.
+             */
+            void drop(const std::string &name);
+
+            /**
+             * @brief Removes all the registered loggers from the registry.
+             *
+             * Each logger will survive until the last copy of it is destroyed
+             * (e.g., goes out of scope).
+             */
+            void dropAll();
+
+            /**
+             * @brief Flush all sinks manually.
+             */
             void flush();
 
             /**

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -130,10 +130,11 @@ namespace util {
                     : logger_(logger), level_(level),
                       os_(new std::ostringstream) {}
 
-                StreamProxy(Logger &logger, LogLevel level, const char *msg)
+                StreamProxy(Logger &logger, LogLevel level,
+                            const std::string &msg)
                     : logger_(logger), level_(level),
                       os_(new std::ostringstream) {
-                    os_->operator<<(msg);
+                    (*os_) << msg;
                 }
 
                 /// destructor appends the finished stringstream at the end

--- a/src/osvr/Util/Log.cpp
+++ b/src/osvr/Util/Log.cpp
@@ -48,8 +48,6 @@ namespace osvr {
 namespace util {
     namespace log {
 
-// TODO if OSVR_ANDROID, use android sink
-
 #ifdef OSVR_UTIL_LOG_SINGLETON
         bool tryInitializingLoggingWithBaseName(std::string const &baseName) {
             auto sanitized = sanitizeFilenamePiece(baseName);
@@ -62,6 +60,12 @@ namespace util {
         LoggerPtr make_logger(const std::string &logger_name) {
             return LogRegistry::instance().getOrCreateLogger(logger_name);
         }
+
+        void drop(const std::string &logger_name) {
+            LogRegistry::instance().drop(logger_name);
+        }
+
+        void dropAll() { LogRegistry::instance().dropAll(); }
 
         void flush() { LogRegistry::instance().flush(); }
 #else
@@ -83,6 +87,14 @@ namespace util {
             spd_logger->set_pattern("%b %d %T.%e %l %n: %v");
             return Logger::makeFromExistingImplementation(logger_name,
                                                           spd_logger);
+        }
+
+        void drop(const std::string &logger_name) {
+            // no-op in the absence of a logger registry.
+        }
+
+        void dropAll() {
+            // no-op in the absence of a logger registry.
         }
 
         void flush() {

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -211,7 +211,7 @@ namespace util {
             // File sink - rotates daily
             std::string logDir;
             try {
-                size_t q_size = 65536; // queue size must be power of 2
+                size_t q_size = 64; // queue size must be power of 2
                 spdlog::set_async_mode(q_size);
                 namespace fs = boost::filesystem;
                 auto base_name = fs::path(getLoggingDirectory(true));

--- a/src/osvr/Util/LogRegistry.cpp
+++ b/src/osvr/Util/LogRegistry.cpp
@@ -113,6 +113,12 @@ namespace util {
                                                           spd_logger);
         }
 
+        void LogRegistry::drop(const std::string &logger_name) {
+            spdlog::drop(logger_name);
+        }
+
+        void LogRegistry::dropAll() { spdlog::drop_all(); }
+
         void LogRegistry::flush() {
             for (auto &sink : sinks_) {
                 try {


### PR DESCRIPTION
- Updated spdlog to incorporate some improvements to the async queue behavior. This will hopefully fix the 'stall on `FreeLibrary()` issue.
- Fixed bug where `logger->info("something")` would print the pointer address instead of the C string.
- Reduced async log queue size to 64 messages. This should drastically improve the memory usage of `osvr_server` at the potential expense of latency in logging messages. If the latency becomes a problem, there are further solutions we can employ.
- Added `drop()` and `dropAll()` functions to unregister a logger with the LogRegistry. If no one else is using the logger, it will be destroyed, flushing its queue and closing its log file in the process.
