### PR TITLE
Qualify use of the apply alias in compose.

### DIFF
--- a/inc/osvr/TypePack/Compose.h
+++ b/inc/osvr/TypePack/Compose.h
@@ -44,7 +44,7 @@ namespace typepack {
     template <typename... Fs> struct compose {};
 
     template <typename F0> struct compose<F0> {
-        template <typename... Ts> using apply = apply<F0, Ts...>;
+        template <typename... Ts> using apply = typepack::apply<F0, Ts...>;
     };
 
     template <typename F0, typename... Fs> struct compose<F0, Fs...> {


### PR DESCRIPTION
Caught by coverity, CID 123543 - it had a parse error, but it apparently
hasn't stopped any of our production code from compiling...
