### PR TITLE
Fix for debug mode keys on linux platforms

### DIFF
--- a/plugins/unifiedvideoinertialtracker/TrackingDebugDisplay.cpp
+++ b/plugins/unifiedvideoinertialtracker/TrackingDebugDisplay.cpp
@@ -394,7 +394,7 @@ namespace vbtracker {
         }
 
         /// Run the event loop briefly to see if there were keyboard presses.
-        int key = cv::waitKey(1);
+        int key = cv::waitKey(1) & 0xff;
         switch (key) {
 
         case 's':

--- a/plugins/videobasedtracker/VideoBasedTracker.cpp
+++ b/plugins/videobasedtracker/VideoBasedTracker.cpp
@@ -319,7 +319,7 @@ namespace vbtracker {
                         std::ostringstream windowName;
                         windowName << "Sensor" << sensor;
                         cv::imshow(windowName.str(), *m_shownImage);
-                        int key = cv::waitKey(1);
+                        int key = cv::waitKey(1) & 0xff;
                         switch (key) {
                         case 's':
                             // Show the concise "status" image (default)


### PR DESCRIPTION
In short, cv::waitKey() returns scancodes (not ascii chars) on non-windows platforms, allowing use of non-ascii jeys (i.e. caps lock, arrow keys etc); However, this means the current code is broken on linux as it cannot correctly identify key presses in two key locations, as most users have numlock on, resulting in a high bit being set in the scankey.

This pull request masks the scancode so any modifier bits are filtered out, making it compatible with char/ascii types.

This fixes the debug window for me on Linux.
