### PR TITLE
Update to Boost 1.62.0.

### DIFF
--- a/cmake-local/BoostTargets.cmake
+++ b/cmake-local/BoostTargets.cmake
@@ -23,8 +23,8 @@ else()
 endif()
 
 find_package(Boost ${OSVR_MIN_BOOST} COMPONENTS ${required_boost_components} REQUIRED)
-if(Boost_VERSION GREATER 106100)
-    # Current max code-reviewed version: Boost 1.61
+if(Boost_VERSION GREATER 106200)
+    # Current max code-reviewed version: Boost 1.62
     # When this is updated - source code must also be updated!
     message(SEND_ERROR "Using an unreviewed Boost version - inspect the Boost Interprocess release notes/changelog/diffs to see if any ABI breaks took place as they may affect client/server interoperability.")
     message(SEND_ERROR "The corresponding source file to update is src/osvr/Common/IPCRingBuffer.cpp")

--- a/src/osvr/Common/IPCRingBuffer.cpp
+++ b/src/osvr/Common/IPCRingBuffer.cpp
@@ -58,7 +58,7 @@ namespace common {
 /// number.
 /// The base boost version test has been moved exclusively to CMake, to error
 /// out earlier.
-#if (BOOST_VERSION > 106100)
+#if (BOOST_VERSION > 106200)
 #error                                                                         \
     "Using an untested Boost version - inspect the Boost Interprocess release notes/changelog to see if any ABI breaks affect us."
 #endif


### PR DESCRIPTION
There were no substantial updates to Boost IPC.

Is this version check still worth doing? Or can we just blacklist the known-bad version(s)?
