### PR TITLE
uninstall numpy installed by pip before installing opencv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_install:
     fi"
 install:
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew uninstall json-c; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then /usr/bin/yes | pip uninstall numpy; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install libusb opencv; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install jsoncpp; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install libfunctionality --HEAD; fi"


### PR DESCRIPTION
Uninstall numpy that was installed by pip before installing opencv, otherwise osx build fails. 
Found this issue that was filed recently - https://github.com/travis-ci/travis-ci/issues/6688 where numpy comes pre-installed by pip, so it conflicts when you do brew install opencv
It caused all the recent Travis builds on OSX to fail, so this should fix the problem
