### PR TITLE
Add missing include to IPCBuffer.cpp

### DIFF
--- a/src/osvr/Common/IPCRingBuffer.cpp
+++ b/src/osvr/Common/IPCRingBuffer.cpp
@@ -30,6 +30,7 @@
 #include <osvr/Common/IPCRingBuffer.h>
 #include <osvr/Util/ImagingReportTypesC.h>
 #include <osvr/Util/Log.h>
+#include <osvr/Util/Logger.h>
 
 // Library/third-party includes
 #include <boost/version.hpp>


### PR DESCRIPTION
Need to include `Logger.h` otherwise it's only a forward-declaration and fails to compile.