### PR TITLE
Update for Boost 1.63

### DIFF
--- a/cmake-local/BoostTargets.cmake
+++ b/cmake-local/BoostTargets.cmake
@@ -23,8 +23,8 @@ else()
 endif()
 
 find_package(Boost ${OSVR_MIN_BOOST} COMPONENTS ${required_boost_components} REQUIRED)
-if(Boost_VERSION GREATER 106200)
-    # Current max code-reviewed version: Boost 1.62
+if(Boost_VERSION GREATER 106300)
+    # Current max code-reviewed version: Boost 1.63
     # When this is updated - source code must also be updated!
     message(SEND_ERROR "Using an unreviewed Boost version - inspect the Boost Interprocess release notes/changelog/diffs to see if any ABI breaks took place as they may affect client/server interoperability.")
     message(SEND_ERROR "The corresponding source file to update is src/osvr/Common/IPCRingBuffer.cpp")

--- a/src/osvr/Common/IPCRingBuffer.cpp
+++ b/src/osvr/Common/IPCRingBuffer.cpp
@@ -59,7 +59,7 @@ namespace common {
 /// number.
 /// The base boost version test has been moved exclusively to CMake, to error
 /// out earlier.
-#if (BOOST_VERSION > 106200)
+#if (BOOST_VERSION > 106300)
 #error                                                                         \
     "Using an untested Boost version - inspect the Boost Interprocess release notes/changelog to see if any ABI breaks affect us."
 #endif


### PR DESCRIPTION
Homebrew uses Boost 1.63, therefore OSVR-Core doesn't compile on MacOS.