### PR TITLE
Added osvr_server command-line options

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -149,7 +149,11 @@ if(BUILD_SERVER_APP)
     add_executable(osvr_server
         osvr_server.cpp
         ${OSVR_SERVER_RESOURCE})
-    target_link_libraries(osvr_server osvrServer JsonCpp::JsonCpp)
+    target_link_libraries(osvr_server
+        osvrServer
+        boost_program_options
+        boost_filesystem
+        JsonCpp::JsonCpp)
     set_target_properties(osvr_server PROPERTIES
         FOLDER "OSVR Stock Applications")
     install(TARGETS osvr_server

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -49,9 +49,8 @@ namespace server {
     /// of the main server app to make alternate server-acting apps simpler to
     /// develop.
     inline ServerPtr configureServerFromString(std::string const &json) {
-        using detail::out;
-        using detail::err;
-        using std::endl;
+        auto log =
+            ::osvr::util::log::make_logger(::osvr::util::log::OSVR_SERVER_LOG);
 
         ServerPtr ret;
         osvr::server::ConfigureServer srvConfig;

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -38,6 +38,7 @@
 #include <exception>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 namespace osvr {
 namespace server {
@@ -157,8 +158,9 @@ namespace server {
             return nullptr;
         }
 
-        std::string json(std::istreambuf_iterator<char>(config), {});
-        return configureServerFromString(json);
+        std::stringstream sstr;
+        sstr << config.rdbuf();
+        return configureServerFromString(sstr.str());
     }
 
 } // namespace server

--- a/inc/osvr/Server/ConfigureServerFromFile.h
+++ b/inc/osvr/Server/ConfigureServerFromFile.h
@@ -48,24 +48,16 @@ namespace server {
     /// @brief This is the basic common code of a server app's setup, ripped out
     /// of the main server app to make alternate server-acting apps simpler to
     /// develop.
-    inline ServerPtr configureServerFromFile(std::string const &configName) {
-        auto log =
-            ::osvr::util::log::make_logger(::osvr::util::log::OSVR_SERVER_LOG);
+    inline ServerPtr configureServerFromString(std::string const &json) {
+        using detail::out;
+        using detail::err;
+        using std::endl;
 
         ServerPtr ret;
-        log->info() << "Using config file '" << configName << "'.";
-        std::ifstream config(configName);
-        if (!config.good()) {
-            log->error() << "Could not open config file!";
-            log->error() << "Searched in the current directory; file may be "
-                            "misspelled, missing, or in a different directory.";
-            return nullptr;
-        }
-
         osvr::server::ConfigureServer srvConfig;
         log->info() << "Constructing server as configured...";
         try {
-            srvConfig.loadConfig(config);
+            srvConfig.loadConfig(json);
             ret = srvConfig.constructServer();
         } catch (std::exception &e) {
             log->error()
@@ -149,6 +141,25 @@ namespace server {
         ret->triggerHardwareDetect();
 
         return ret;
+    }
+
+    /// @Brief Convenience wrapper for configureServerFromString().
+    inline ServerPtr configureServerFromFile(std::string const &configName) {
+        auto log =
+            ::osvr::util::log::make_logger(::osvr::util::log::OSVR_SERVER_LOG);
+
+        ServerPtr ret;
+        log->info() << "Using config file '" << configName << "'.";
+        std::ifstream config(configName);
+        if (!config.good()) {
+            log->error() << "Could not open config file!";
+            log->error() << "Searched in the current directory; file may be "
+                            "misspelled, missing, or in a different directory.";
+            return nullptr;
+        }
+
+        std::string json(std::istreambuf_iterator<char>(config), {});
+        return configureServerFromString(json);
     }
 
 } // namespace server

--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -29,6 +29,7 @@
 // Internal Includes
 #include <osvr/Util/Log.h> // for LoggerPtr forward declaration
 #include <osvr/Util/LogLevel.h>
+#include <osvr/Util/Export.h>
 
 // Library/third-party includes
 // - none
@@ -57,12 +58,12 @@ namespace util {
 
         class LogRegistry {
           public:
-            LogRegistry(LogRegistry const &) = delete; // copy construct
-            LogRegistry(LogRegistry &&) = delete;      // move construct
-            LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
-            LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
+            OSVR_UTIL_EXPORT LogRegistry(LogRegistry const &) = delete; // copy construct
+            OSVR_UTIL_EXPORT LogRegistry(LogRegistry &&) = delete;      // move construct
+            OSVR_UTIL_EXPORT LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
+            OSVR_UTIL_EXPORT LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
 
-            static LogRegistry &instance(std::string const * = nullptr);
+            OSVR_UTIL_EXPORT static LogRegistry &instance(std::string const * = nullptr);
 
             /**
              * @brief Gets or creates a logger named @c logger_name.
@@ -73,7 +74,7 @@ namespace util {
              * @param logger_name The name of the logger.
              *
              */
-            LoggerPtr getOrCreateLogger(const std::string &logger_name);
+            OSVR_UTIL_EXPORT LoggerPtr getOrCreateLogger(const std::string &logger_name);
 
             /**
              * @brief Drops a logger from the registry.
@@ -82,7 +83,7 @@ namespace util {
              * (e.g., goes out of scope). This function is useful if you want to
              * destroy a logger before the program terminates.
              */
-            void drop(const std::string &name);
+            OSVR_UTIL_EXPORT void drop(const std::string &name);
 
             /**
              * @brief Removes all the registered loggers from the registry.
@@ -90,39 +91,39 @@ namespace util {
              * Each logger will survive until the last copy of it is destroyed
              * (e.g., goes out of scope).
              */
-            void dropAll();
+            OSVR_UTIL_EXPORT void dropAll();
 
             /**
              * @brief Flush all sinks manually.
              */
-            void flush();
+            OSVR_UTIL_EXPORT void flush();
 
             /**
              * @brief Sets the output pattern on all registered loggers.
              */
-            void setPattern(const std::string &pattern);
+            OSVR_UTIL_EXPORT void setPattern(const std::string &pattern);
 
             /**
              * @brief Sets the minimum level of messages to be logged on all
              * registered loggers.
              */
-            void setLevel(LogLevel severity);
+            OSVR_UTIL_EXPORT void setLevel(LogLevel severity);
 
             /**
              * @brief Sets the minimum level of messages to be logged to the
              * console.
              */
-            void setConsoleLevel(LogLevel severity);
+            OSVR_UTIL_EXPORT void setConsoleLevel(LogLevel severity);
 
-            std::string const &getLogFileBaseName() const {
+            OSVR_UTIL_EXPORT std::string const &getLogFileBaseName() const {
                 return logFileBaseName_;
             }
 
-            bool couldOpenLogFile() const { return sinks_.size() > 1; }
+            OSVR_UTIL_EXPORT bool couldOpenLogFile() const { return sinks_.size() > 1; }
 
           protected:
-            LogRegistry(std::string const &logFileBaseName);
-            ~LogRegistry();
+            OSVR_UTIL_EXPORT LogRegistry(std::string const &logFileBaseName);
+            OSVR_UTIL_EXPORT ~LogRegistry();
 
           private:
             void setLevelImpl(LogLevel severity);


### PR DESCRIPTION
This PR adds command-line options to the server for adjusting the log verbosity and also allows the server to run without specifying a configuration file (in which case it will assume an empty configuration `{ }`).

```
$ ./osvr_server --help
Command Line Options:
  --help                display this help message
  -v [ --verbose ]      enable verbose logging
  -d [ --debug ]        enable debug logging
```

Verbose logging sets the log level to `debug` and debug logging sets the log level to `trace`.

This subsumes PR #293 by @Outurnate.