### PR TITLE
remove boost version check

### DIFF
--- a/cmake-local/BoostTargets.cmake
+++ b/cmake-local/BoostTargets.cmake
@@ -23,12 +23,6 @@ else()
 endif()
 
 find_package(Boost ${OSVR_MIN_BOOST} COMPONENTS ${required_boost_components} REQUIRED)
-if(Boost_VERSION GREATER 106300)
-    # Current max code-reviewed version: Boost 1.63
-    # When this is updated - source code must also be updated!
-    message(SEND_ERROR "Using an unreviewed Boost version - inspect the Boost Interprocess release notes/changelog/diffs to see if any ABI breaks took place as they may affect client/server interoperability.")
-    message(SEND_ERROR "The corresponding source file to update is src/osvr/Common/IPCRingBuffer.cpp")
-endif()
 
 if(NEED_BOOST_THREAD)
     add_library(boost_thread INTERFACE)

--- a/src/osvr/Common/IPCRingBuffer.cpp
+++ b/src/osvr/Common/IPCRingBuffer.cpp
@@ -55,15 +55,6 @@ namespace common {
     /// that would interfere with communication.
     static IPCRingBuffer::abi_level_type SHM_SOURCE_ABI_LEVEL = 0;
 
-/// Some tests that can be automated for ensuring validity of the ABI level
-/// number.
-/// The base boost version test has been moved exclusively to CMake, to error
-/// out earlier.
-#if (BOOST_VERSION > 106300)
-#error                                                                         \
-    "Using an untested Boost version - inspect the Boost Interprocess release notes/changelog to see if any ABI breaks affect us."
-#endif
-
 #ifdef _WIN32
 #if (BOOST_VERSION < 105400)
 #error                                                                         \


### PR DESCRIPTION
There once was a boost release that broke some ABI.
This has not happened again in a looong time, so remove the inconvenience of having to update this check after every boost release.

In my opinion it would be far better to document the faulty boost version in a "known issues" section in the Readme instead of having this rather pointless check in the code and failing the build.

If this is not acceptable, maybe the compile error could at least be made into a warning?