### PR TITLE
Just in timewarp

### DIFF
--- a/inc/osvr/Client/RenderManagerConfig.h
+++ b/inc/osvr/Client/RenderManagerConfig.h
@@ -95,6 +95,8 @@ namespace osvr {
                 {
                     auto &timeWarp = params["timeWarp"];
                     m_enableTimeWarp = timeWarp["enabled"].asBool();
+                    m_justInTimeWarp = timeWarp["justInTime"].asBool();
+                    m_justInTimeWarpRotation = timeWarp["justInTimeRotation"].asFloat();
                     m_asynchronousTimeWarp = timeWarp["asynchronous"].asBool();
                     m_maxMSBeforeVsyncTimeWarp = timeWarp["maxMsBeforeVSync"].asFloat();
                 }
@@ -159,6 +161,16 @@ namespace osvr {
             inline bool getAsynchronousTimeWarp() const
             {
                 return m_asynchronousTimeWarp;
+            }
+
+            inline bool getJustInTimeWarp() const
+            {
+              return m_justInTimeWarp;
+            }
+
+            inline float getJustInTimeWarpRotation() const
+            {
+              return m_justInTimeWarpRotation;
             }
 
             inline float getMaxMSBeforeVsyncTimeWarp() const
@@ -267,6 +279,8 @@ namespace osvr {
             bool m_predictLocalTimeOverride;
 
             bool m_enableTimeWarp;
+            bool m_justInTimeWarp;
+            float m_justInTimeWarpRotation;
             bool m_asynchronousTimeWarp;
             float m_maxMSBeforeVsyncTimeWarp;
             float m_renderOverfillFactor;

--- a/inc/osvr/Client/RenderManagerConfig.h
+++ b/inc/osvr/Client/RenderManagerConfig.h
@@ -96,7 +96,6 @@ namespace osvr {
                     auto &timeWarp = params["timeWarp"];
                     m_enableTimeWarp = timeWarp["enabled"].asBool();
                     m_justInTimeWarp = timeWarp["justInTime"].asBool();
-                    m_justInTimeWarpRotation = timeWarp["justInTimeRotation"].asFloat();
                     m_asynchronousTimeWarp = timeWarp["asynchronous"].asBool();
                     m_maxMSBeforeVsyncTimeWarp = timeWarp["maxMsBeforeVSync"].asFloat();
                 }
@@ -166,11 +165,6 @@ namespace osvr {
             inline bool getJustInTimeWarp() const
             {
               return m_justInTimeWarp;
-            }
-
-            inline float getJustInTimeWarpRotation() const
-            {
-              return m_justInTimeWarpRotation;
             }
 
             inline float getMaxMSBeforeVsyncTimeWarp() const
@@ -280,7 +274,6 @@ namespace osvr {
 
             bool m_enableTimeWarp;
             bool m_justInTimeWarp;
-            float m_justInTimeWarpRotation;
             bool m_asynchronousTimeWarp;
             float m_maxMSBeforeVsyncTimeWarp;
             float m_renderOverfillFactor;

--- a/inc/osvr/Common/DegreesToRadians.h
+++ b/inc/osvr/Common/DegreesToRadians.h
@@ -40,6 +40,10 @@ namespace common {
         using namespace boost::math::double_constants;
         return degrees * pi / 180.0;
     }
+    inline double radiansToDegrees(double degrees) {
+      using namespace boost::math::double_constants;
+      return degrees * 180.0 / pi;
+    }
 } // namespace common
 } // namespace osvr
 #endif // INCLUDED_DegreesToRadians_h_GUID_8354A4E2_30FF_429C_2569_E83EEF10E13A


### PR DESCRIPTION
This has been modified to only include the specification of whether we are using just-in-timewarp, the scan orientation has been moved to OSVR-RenderManager.

This must be merged before we can merge the just-in-timewarp branch from RenderManager.