### PR TITLE
Updated the signature of the reportFrame method in ImagingInterfaceC.cpp

### DIFF
--- a/src/osvr/PluginKit/ImagingInterfaceC.cpp
+++ b/src/osvr/PluginKit/ImagingInterfaceC.cpp
@@ -49,11 +49,11 @@ OSVR_ImageBufferElement *gLastFrameBuffer = NULL;
 OSVR_ImagingMetadata gLastFrameMetadata;
 
 extern "C" {
-    JNIEXPORT void JNICALL Java_com_osvr_android_jni_JNIBridge_reportFrame(JNIEnv * env, jclass clazz,
+    JNIEXPORT void JNICALL Java_com_osvr_common_jni_JNIBridge_reportFrame(JNIEnv * env, jclass clazz,
       jbyteArray data, jlong width, jlong height);
 }
 
-JNIEXPORT void JNICALL Java_com_osvr_android_jni_JNIBridge_reportFrame(JNIEnv * env, jclass clazz,
+JNIEXPORT void JNICALL Java_com_osvr_common_jni_JNIBridge_reportFrame(JNIEnv * env, jclass clazz,
     jbyteArray data, jlong width, jlong height) {
 
     gLastFrameMetadata.height = (OSVR_ImageDimension)height;


### PR DESCRIPTION
Settled on this signature for now as part of the common library. TODO in future pull request: move this JNI function out of OSVR-Core and into the jniImaging plugin now that JNI calls work in plugins.