### PR TITLE
Remove export declarations from deleted/inline functions

### DIFF
--- a/inc/osvr/Util/LogRegistry.h
+++ b/inc/osvr/Util/LogRegistry.h
@@ -58,10 +58,10 @@ namespace util {
 
         class LogRegistry {
           public:
-            OSVR_UTIL_EXPORT LogRegistry(LogRegistry const &) = delete; // copy construct
-            OSVR_UTIL_EXPORT LogRegistry(LogRegistry &&) = delete;      // move construct
-            OSVR_UTIL_EXPORT LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
-            OSVR_UTIL_EXPORT LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
+            LogRegistry(LogRegistry const &) = delete; // copy construct
+            LogRegistry(LogRegistry &&) = delete;      // move construct
+            LogRegistry &operator=(LogRegistry const &) = delete; // copy assign
+            LogRegistry &operator=(LogRegistry &&) = delete;      // move assign
 
             OSVR_UTIL_EXPORT static LogRegistry &instance(std::string const * = nullptr);
 
@@ -115,11 +115,11 @@ namespace util {
              */
             OSVR_UTIL_EXPORT void setConsoleLevel(LogLevel severity);
 
-            OSVR_UTIL_EXPORT std::string const &getLogFileBaseName() const {
+            std::string const &getLogFileBaseName() const {
                 return logFileBaseName_;
             }
 
-            OSVR_UTIL_EXPORT bool couldOpenLogFile() const { return sinks_.size() > 1; }
+            bool couldOpenLogFile() const { return sinks_.size() > 1; }
 
           protected:
             OSVR_UTIL_EXPORT LogRegistry(std::string const &logFileBaseName);

--- a/inc/osvr/Util/Logger.h
+++ b/inc/osvr/Util/Logger.h
@@ -101,10 +101,10 @@ namespace util {
                           spdlog::sinks_init_list sinks);
 
             /// Non-copyable
-            OSVR_UTIL_EXPORT Logger(const Logger &) = delete;
+            Logger(const Logger &) = delete;
 
             /// Non-copy-assignable
-            OSVR_UTIL_EXPORT Logger &operator=(const Logger &) = delete;
+            Logger &operator=(const Logger &) = delete;
 
             /// Destructor
             OSVR_UTIL_EXPORT ~Logger();
@@ -203,7 +203,7 @@ namespace util {
             OSVR_UTIL_EXPORT void flush();
 
             /// Get the logger name
-            OSVR_UTIL_EXPORT std::string const &getName() const {
+            std::string const &getName() const {
                 return name_;
             }
 


### PR DESCRIPTION
This was sitting in my VS2017 branch, but I imagine it would also fix #570 . Pretty simple: don't import/export from DLL functions that are deleted or inline.