### PR TITLE
Avoid leaking the build-time Boost path into the CMake config file.

### DIFF
--- a/src/osvr/Client/CMakeLists.txt
+++ b/src/osvr/Client/CMakeLists.txt
@@ -74,7 +74,7 @@ set_property(TARGET ${LIBNAME_FULL} APPEND PROPERTY
 
 target_include_directories(${LIBNAME_FULL}
     PUBLIC
-    ${Boost_INCLUDE_DIRS})
+    $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
 
 target_link_libraries(${LIBNAME_FULL}
     PRIVATE


### PR DESCRIPTION
Fixes #568 