### PR TITLE
Add udev rules

### DIFF
--- a/udev-rules.d/99-osvr-hdk-camera.rules
+++ b/udev-rules.d/99-osvr-hdk-camera.rules
@@ -1,0 +1,6 @@
+# udev file for OSVR HDK positional tracking camera
+# Copyright 2018 Collabora
+# SPDX-License-Identifier: Apache-2.0
+
+# OSVR HDK Camera (via libusb/libuvc)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="57e8", MODE="0660", GROUP="plugdev"

--- a/udev-rules.d/99-osvr-sensics-usb.rules
+++ b/udev-rules.d/99-osvr-sensics-usb.rules
@@ -1,0 +1,26 @@
+# udev file for USB interfaces on Sensics-based HMDs and emulated devices
+# Copyright 2015-2016, Sensics, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+###
+# Section to permit access to HID streaming
+###
+
+# OSVR HDK (via HIDAPI/libusb)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0b00", MODE="0660", GROUP="plugdev"
+
+# OSVR HDK (via HIDAPI/hidraw)
+KERNEL=="hidraw*", ATTRS{busnum}=="1", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0b00", MODE="0660", GROUP="plugdev"
+
+###
+# Section for the usb-serial interface: useful name, ignored by modemmanager
+###
+
+# OSVR HDK
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0b00", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0b00", SYMLINK+="ttyUSB.OSVRHDK"
+
+# Sensics zSight
+SUBSYSTEM=="usb", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0515", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0515", SYMLINK+="ttyUSB.zSight"
+


### PR DESCRIPTION
Not sure why I didn't commit these long ago - most of them have been sitting around in a Gist since 2015.

No build system touches them yet but this at least puts them in the source tree.

**Question** - is `MODE="0660" GROUP="plugdev"` the best thing to do to provide USB access? It's different from what the Vive linux support does - https://github.com/ValveSoftware/SteamVR-for-Linux#usb-device-requirements