### PR TITLE
Some windows build fixes

### DIFF
--- a/inc/osvr/Util/EigenFilters.h
+++ b/inc/osvr/Util/EigenFilters.h
@@ -102,7 +102,7 @@ namespace util {
                 /// Computing the alpha value for a step in the one euro filter
                 /// for any scalar type.
                 template <typename T> inline T computeAlpha(T dt, T cutoff) {
-                    auto tau = T(1) / (T(2) * M_PI * cutoff);
+                    auto tau = T(1) / (T(2) * EIGEN_PI * cutoff);
                     return T(1) / (T(1) + tau / dt);
                 }
 

--- a/src/osvr/Common/CMakeLists.txt
+++ b/src/osvr/Common/CMakeLists.txt
@@ -215,6 +215,12 @@ target_link_libraries(${LIBNAME_FULL}
     osvr_cxx11_flags
     ${OSVR_CODECVT_LIBRARIES})
 
+target_compile_definitions(${LIBNAME_FULL} PRIVATE BOOST_DATE_TIME_NO_LIB)
+if(WIN32)
+    target_link_libraries(${LIBNAME_FULL} PRIVATE 
+        ${Boost_DATE_TIME_LIBRARY})
+endif()
+
 if(OSVR_COMMON_TRACING_ETW)
     target_link_libraries(${LIBNAME_FULL} PRIVATE ETWProviders)
     add_custom_command(TARGET ${LIBNAME_FULL} POST_BUILD

--- a/src/osvr/Common/SharedMemory.h
+++ b/src/osvr/Common/SharedMemory.h
@@ -29,9 +29,6 @@
 /// see http://stackoverflow.com/a/2335693/265522
 #define BOOST_CB_DISABLE_DEBUG
 
-/// Allows header-only usage of Interprocess
-#define BOOST_DATE_TIME_NO_LIB
-
 /// @todo This is a workaround for Clang and Boost pre-1.50, to fix a build
 /// error caused by a syntax error in Boost.Containers allocator traits.
 #include <boost/version.hpp>


### PR DESCRIPTION
Everything but the gtest tests builds with msvc 2019 now.