### PR TITLE
uvbi: Make sure we link against enough opencv libs

### DIFF
--- a/plugins/unifiedvideoinertialtracker/CMakeLists.txt
+++ b/plugins/unifiedvideoinertialtracker/CMakeLists.txt
@@ -85,6 +85,8 @@ target_link_libraries(uvbi-core
     PUBLIC
     ${VIDEOTRACKER_EXTRA_LIBS}
     opencv_core
+    opencv_imgproc
+    opencv_videoio
     osvrUtilCpp # for typedefs and boost headers
     osvrKalman
     eigen-headers
@@ -99,7 +101,7 @@ target_compile_definitions(uvbi-core PRIVATE OSVR_UVBI_CORE)
 # Convenience tool to view the tracker camera using the same pipeline as the tracker plugin.
 ###
 add_executable(uvbi-view-camera ViewTrackingCamera.cpp)
-target_link_libraries(uvbi-view-camera PRIVATE uvbi-image-sources)
+target_link_libraries(uvbi-view-camera PRIVATE uvbi-image-sources opencv_imgcodecs)
 set_target_properties(uvbi-view-camera PROPERTIES
     FOLDER "${PROJ_FOLDER}")
 

--- a/plugins/unifiedvideoinertialtracker/ImageSources/CMakeLists.txt
+++ b/plugins/unifiedvideoinertialtracker/ImageSources/CMakeLists.txt
@@ -34,6 +34,8 @@ set_target_properties(uvbi-image-sources PROPERTIES
 target_link_libraries(uvbi-image-sources PUBLIC
     opencv_core
     opencv_highgui
+    opencv_videoio
+    opencv_imgproc
     ${VIDEOTRACKER_EXTRA_LIBS}
     osvrUtil
     PRIVATE

--- a/plugins/videotrackershared/CMakeLists.txt
+++ b/plugins/videotrackershared/CMakeLists.txt
@@ -55,6 +55,8 @@ if(BUILD_ADVANCED_DEV_TOOLS)
         PUBLIC
         ${VIDEOTRACKER_EXTRA_LIBS}
         opencv_core
+        opencv_imgproc
+        opencv_image2d
         osvrUtil
         JsonCpp::JsonCpp)
     target_compile_definitions(blob_extraction_demo


### PR DESCRIPTION
Found this when trying to build it outside of the tree, figured I should backport it.